### PR TITLE
feat: add shattered veil chalkboard code tool

### DIFF
--- a/components/rich-text/rich-embeds/reckoning-code.tsx
+++ b/components/rich-text/rich-embeds/reckoning-code.tsx
@@ -105,10 +105,6 @@ export default function ReckoningCode() {
 		}
 	}
 
-	const isLetterActive = (letter: string) => {
-		return selectedLetters.includes(letter)
-	}
-
 	const isLetterDisabled = (letter: string) => {
 		if (selectedLetters.length === 0) return false
 		if (selectedLetters.includes(letter)) return false // Allow clicking selected letters to unselect them
@@ -128,7 +124,7 @@ export default function ReckoningCode() {
 							disabled={isLetterDisabled(letter)}
 							onClick={() => handleLetterClick(letter)}
 							aria-label={`Select ${letter}`}
-							className={`text-lg uppercase ${isLetterActive(letter) ? "bg-primary text-primary-foreground" : ""} ${isLetterDisabled(letter) ? "cursor-not-allowed opacity-25" : ""}`}
+							className={`text-lg uppercase`}
 						>
 							{letter}
 						</Toggle>

--- a/components/rich-text/rich-embeds/shattered-veil-chalkboard-code.tsx
+++ b/components/rich-text/rich-embeds/shattered-veil-chalkboard-code.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card"
+import { type ChalkboardLetters, type Code, chalkboardCodes } from "@/data/shattered-veil-codes"
+
+const getAllCodes = () => {
+	const codeWords: Code[] = []
+
+	// We can use any property for this loop since they all have the same four possible code words
+	for (const code in chalkboardCodes.E) {
+		codeWords.push(code as Code)
+	}
+
+	return codeWords
+}
+
+export default function ShatteredVeilCode() {
+	const [letterGroup, setLetterGroup] = useState<ChalkboardLetters>()
+	const [codeWord, setCodeWord] = useState<Code>()
+	const allLetterGroups = Object.keys(chalkboardCodes) as ChalkboardLetters[]
+	const allCodeWords = getAllCodes()
+
+	return (
+		<div className="flex items-center justify-center bg-background p-4">
+			<Card className="w-full bg-transparent">
+				<CardHeader>
+					<CardTitle>Keypad Code Generator</CardTitle>
+					<CardDescription>Select one option from each group to generate your code</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-6">
+					{/* Code Words Group */}
+					<div className="space-y-3">
+						<h3 className="font-semibold text-foreground/90 text-sm">Code Words</h3>
+						<div className="grid grid-cols-2 gap-2">
+							{allCodeWords.map(word => (
+								<Button
+									key={word}
+									variant={codeWord === word ? "default" : "outline"}
+									onClick={() => setCodeWord(word)}
+									className="w-full"
+								>
+									{word}
+								</Button>
+							))}
+						</div>
+					</div>
+
+					{/* Letter Groups */}
+					<div className="space-y-3">
+						<h3 className="font-semibold text-foreground/90 text-sm">Letter Groups</h3>
+						<div className="grid grid-cols-2 gap-2">
+							{allLetterGroups.map(group => (
+								<Button
+									key={group}
+									variant={letterGroup === group ? "default" : "outline"}
+									onClick={() => setLetterGroup(group)}
+									className="w-full"
+								>
+									{group}
+								</Button>
+							))}
+						</div>
+					</div>
+
+					{/* Generated Code Display */}
+					{letterGroup && codeWord && (
+						<div className="border-t pt-4">
+							<p className="mb-2 text-foreground/90 text-sm">Your Code:</p>
+							<div className="rounded-lg bg-muted p-4 dark:bg-input/30">
+								<code className="font-mono font-semibold text-foreground text-lg">
+									{chalkboardCodes[letterGroup][codeWord]}
+								</code>
+							</div>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	)
+
+	// return (
+	// 	<Card className="my-8 bg-transparent shadow-lg dark:shadow-none">
+	// 		<CardContent className="flex flex-col items-center justify-center gap-4">
+	// 			<div className="flex items-center justify-center gap-4">
+	// 				<span>Select Code Word:</span>
+	// 				<div className="flex items-center justify-center gap-2">
+	// 					{allCodeWords.map(code => (
+	// 						<Toggle
+	// 							key={code}
+	// 							variant={"outline"}
+	// 							onClick={() => handleCodeWordClick(code)}
+	// 							disabled={isCodeDisabled(code)}
+	// 							aria-label={`Select ${code}`}
+	// 						>
+	// 							{code}
+	// 						</Toggle>
+	// 					))}
+	// 				</div>
+	// 			</div>
+	// 			<div className="flex items-center justify-center gap-4">
+	// 				<span>Select First Letter Group:</span>
+	// 				<div className="flex items-center justify-center gap-2">
+	// 					{allLetterGroups.map(group => (
+	// 						<Toggle
+	// 							key={group}
+	// 							variant={"outline"}
+	// 							disabled={isGroupDisabled(group)}
+	// 							aria-label={`Select ${group}`}
+	// 							onClick={() => handleLetterGroupClick(group)}
+	// 						>
+	// 							{group}
+	// 						</Toggle>
+	// 					))}
+	// 				</div>
+	// 			</div>
+	// 		</CardContent>
+	// 		<CardFooter className="flex items-center justify-center">
+	// 			<div className="flex items-center justify-center text-center text-base">
+	// 				<span>
+	// 					Keypad Code:
+	// 					{letterGroup && codeWord && (
+	// 						<span className="ml-1 font-bold">{chalkboardCodes[letterGroup][codeWord]}</span>
+	// 					)}
+	// 				</span>
+	// 			</div>
+	// 		</CardFooter>
+	// 	</Card>
+	// )
+}

--- a/content/main-quests/shattered-veil.mdx
+++ b/content/main-quests/shattered-veil.mdx
@@ -9,6 +9,7 @@ import FieldUpgradeTooltip from "@/components/rich-text/rich-tooltips/field-upgr
 import AmmoModTooltip from "@/components/rich-text/rich-tooltips/ammo-mod-tooltip"
 import WeaponBuildTooltip from "@/components/rich-text/rich-tooltips/weapon-build-tooltip"
 import AugmentTooltip from "@/components/rich-text/rich-tooltips/augment-tooltip"
+import ShatteredVeilCode from "@/components/rich-text/rich-embeds/shattered-veil-chalkboard-code"
 
 ## Main Quest
 This main quest has our crew of **Weaver**, **Grey**, **Carver**, and **Maya** traveling back to **Liberty Falls** with the **Sentinel Artifact**, hoping to save **Agent Maxis**.
@@ -135,8 +136,10 @@ letters in that group to get a digit of the four-digit code needed.
 <RichImage image='/content/shattered-veil/shattered-veil-sheet.webp' caption='Fax Machine Sheet' />
 <RichImage image='/content/shattered-veil/shattered-veil-chalkboard.webp' caption='Nursery Chalkboard' />
 
-> To explain this further, if your protocol is **CRAB**, you will first look for which group of letters contains the letter **C**, then you will count how many letters are in that group. 
-That number will be the first digit of your four-digit code, and you must repeat that for the other three letters of your protocol. In the image above the code would be: **9729**
+> You can use the tool below to get your code since there are only 20 possible combinations. In the images above, our word was **CRAB** and the first letter group on our
+chalkboard was **E**, so selecting those two will get us our **Keypad Code: 9729**. The first letter group is always the **Top-Left** group on the chalkboard.
+
+<ShatteredVeilCode />
 
 Once you have the four-digit code, head down to the **Service Tunnel**, interact with the keypad on the door containing the HVT <ZombieTooltip zombieKey='doppelghast' />, 
 and enter the four-digit code into the keypad to free it. Once freed, you must kill the HVT <ZombieTooltip zombieKey='doppelghast' /> to obtain the **Severed Arm**.

--- a/data/shattered-veil-codes.ts
+++ b/data/shattered-veil-codes.ts
@@ -1,0 +1,37 @@
+export const codeWords = [
+  "CRAB",
+  "YETI",
+  "MOTH",
+  "WORM"
+] as const
+
+export type Code = (typeof codeWords)[number]
+
+export const chalkboardCodes = {
+  "E": {
+    "CRAB": 9729,
+    "YETI": 3192,
+    "MOTH": 7394,
+    "WORM": 9377
+  },
+  "BCDEF": {
+    "CRAB": 5775,
+    "YETI": 3576,
+    "MOTH": 1676,
+    "WORM": 7671
+  },
+  "OSTUHJLD": {
+    "CRAB": 4664,
+    "YETI": 5482,
+    "MOTH": 1888,
+    "WORM": 5861
+  },
+  "AIOUY": {
+    "CRAB": 7857,
+    "YETI": 5785,
+    "MOTH": 8587,
+    "WORM": 8588
+  }
+} as const
+
+export type ChalkboardLetters = keyof typeof chalkboardCodes


### PR DESCRIPTION
Adds a tool for solving the shattered veil chalkboard puzzle to quickly get the desired keypad code.

Closes [CODZG-90](https://linear.app/codzombiesguides/issue/CODZG-90/add-shattered-veil-tool-for-solving-the-chalkboard-code)
