### PR TITLE
chore: add update-last-modified github workflow

### DIFF
--- a/.github/workflows/update-last-modified.yml
+++ b/.github/workflows/update-last-modified.yml
@@ -1,0 +1,50 @@
+name: Update Last Modified Dates
+
+on:
+  pull_request:
+    paths:
+      - 'content/**/*.mdx'
+    types: [opened, synchronize]
+
+jobs:
+  update-last-modified:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PlagueFPS'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for git log analysis
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run generate-last-modified script
+        run: bun run scripts/generate-last-modified.ts
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet data/last-modified.json; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit changes to PR
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/last-modified.json
+          git commit -m "chore: update last modified dates"
+          git push


### PR DESCRIPTION
Adds a custom `update-last-modified` github workflow to ensure last-modified dates are always up-to-date and consistent across production builds.