### PR TITLE
perf: remove prefetch prop override on CustomLink component

### DIFF
--- a/components/custom-link/custom-link.tsx
+++ b/components/custom-link/custom-link.tsx
@@ -5,54 +5,52 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 interface ICustomLink<T extends string> extends LinkProps<T> {
-  href: Route<T>;
+	href: Route<T>;
 }
 
 export function CustomLink<T extends string>({
-  children,
-  href,
-  ...props
+	children,
+	href,
+	...props
 }: ICustomLink<T>) {
-  const router = useRouter();
+	const router = useRouter();
 
-  const handleNavigation = (
-    e:
-      | React.MouseEvent<HTMLAnchorElement>
-      | React.KeyboardEvent<HTMLAnchorElement>,
-  ) => {
-    if (!href) return;
-    const url = new URL(href, window.location.href);
-    if (
-      url.origin === window.location.origin &&
-      !e.altKey &&
-      !e.shiftKey &&
-      !e.ctrlKey &&
-      !e.metaKey &&
-      (("button" in e && e.button === 0) || ("key" in e && e.key === "Enter"))
-    ) {
-      e.preventDefault();
-      router.push(href);
-    }
-  };
+	const handleNavigation = (
+		e:
+			| React.MouseEvent<HTMLAnchorElement>
+			| React.KeyboardEvent<HTMLAnchorElement>,
+	) => {
+		if (!href) return;
+		const url = new URL(href, window.location.href);
+		if (
+			url.origin === window.location.origin &&
+			!e.altKey &&
+			!e.shiftKey &&
+			!e.ctrlKey &&
+			!e.metaKey &&
+			(("button" in e && e.button === 0) || ("key" in e && e.key === "Enter"))
+		) {
+			e.preventDefault();
+			router.push(href);
+		}
+	};
 
-  return (
-    <Link
-      {...props}
-      // Disable prefetching by default, but allow it to be overidden on a per-link basis
-      prefetch={props.prefetch ?? false}
-      href={href}
-      onMouseDown={handleNavigation}
-      onKeyDown={handleNavigation}
-      // We use this to prevent double navigations since we use `router.push()`
-      // for mouse/key down navigations, resulting in a seemingly faster experience.
-      onNavigate={(e) => {
-        e.preventDefault();
-        props?.onNavigate?.(e);
-      }}
-    >
-      {children}
-    </Link>
-  );
+	return (
+		<Link
+			{...props}
+			href={href}
+			onMouseDown={handleNavigation}
+			onKeyDown={handleNavigation}
+			// We use this to prevent double navigations since we use `router.push()`
+			// for mouse/key down navigations, resulting in a seemingly faster experience.
+			onNavigate={(e) => {
+				e.preventDefault();
+				props?.onNavigate?.(e);
+			}}
+		>
+			{children}
+		</Link>
+	);
 }
 /**
  * This component properly handles the scrolling of hash links for hard navigations
@@ -60,61 +58,61 @@ export function CustomLink<T extends string>({
  * @see https://nextjs.org/docs/app/api-reference/components/link#scrolling-to-an-id
  */
 export const HashLinkHandler = () => {
-  const pathname = usePathname();
+	const pathname = usePathname();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies(pathname): we want to run this effect when the pathname changes
-  useEffect(() => {
-    const handleHashScroll = () => {
-      const hash = window.location.hash;
-      if (!hash) return;
+	// biome-ignore lint/correctness/useExhaustiveDependencies(pathname): we want to run this effect when the pathname changes
+	useEffect(() => {
+		const handleHashScroll = () => {
+			const hash = window.location.hash;
+			if (!hash) return;
 
-      const elementId = hash.substring(1);
-      const element = document.getElementById(elementId);
+			const elementId = hash.substring(1);
+			const element = document.getElementById(elementId);
 
-      if (element) {
-        // Add a small delay to ensure the page is fully rendered
-        setTimeout(() => {
-          element.scrollIntoView({
-            behavior: "instant",
-            block: "start",
-          });
-        }, 50);
-      } else {
-        // If element doesn't exist yet, keep trying for a few seconds
-        let attempts = 0;
-        const maxAttempts = 20; // 1 second (20 * 50ms)
+			if (element) {
+				// Add a small delay to ensure the page is fully rendered
+				setTimeout(() => {
+					element.scrollIntoView({
+						behavior: "instant",
+						block: "start",
+					});
+				}, 50);
+			} else {
+				// If element doesn't exist yet, keep trying for a few seconds
+				let attempts = 0;
+				const maxAttempts = 20; // 1 second (20 * 50ms)
 
-        const retryScroll = setInterval(() => {
-          const retryElement = document.getElementById(elementId);
-          attempts++;
+				const retryScroll = setInterval(() => {
+					const retryElement = document.getElementById(elementId);
+					attempts++;
 
-          if (retryElement) {
-            retryElement.scrollIntoView({
-              behavior: "instant",
-              block: "start",
-            });
-            clearInterval(retryScroll);
-          } else if (attempts >= maxAttempts) {
-            clearInterval(retryScroll);
-          }
-        }, 50);
-      }
-    };
+					if (retryElement) {
+						retryElement.scrollIntoView({
+							behavior: "instant",
+							block: "start",
+						});
+						clearInterval(retryScroll);
+					} else if (attempts >= maxAttempts) {
+						clearInterval(retryScroll);
+					}
+				}, 50);
+			}
+		};
 
-    // Handle initial page load
-    if (typeof window !== "undefined") {
-      // Wait for the page to be fully loaded
-      if (document.readyState === "complete") {
-        handleHashScroll();
-      } else {
-        window.addEventListener("load", handleHashScroll);
-      }
-    }
+		// Handle initial page load
+		if (typeof window !== "undefined") {
+			// Wait for the page to be fully loaded
+			if (document.readyState === "complete") {
+				handleHashScroll();
+			} else {
+				window.addEventListener("load", handleHashScroll);
+			}
+		}
 
-    return () => {
-      window.removeEventListener("load", handleHashScroll);
-    };
-  }, [pathname]);
+		return () => {
+			window.removeEventListener("load", handleHashScroll);
+		};
+	}, [pathname]);
 
-  return null;
+	return null;
 };

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -54,6 +54,7 @@ export default function Footer() {
 			</div>
 			<div className="flex w-full items-center justify-center text-muted-foreground text-xs md:mt-2 md:justify-start">
 				<CustomLink
+					prefetch={false}
 					href="/privacy-policy"
 					className="underline underline-offset-2 hover:text-foreground hover:no-underline dark:hover:text-foreground/80"
 				>

--- a/components/interactive-map/preview-card.tsx
+++ b/components/interactive-map/preview-card.tsx
@@ -7,50 +7,49 @@ import { Badge } from "../ui/badge"
 import PreviewCardImage from "./preview-card-image"
 
 interface IPreviewCard {
-  mapId: MapId
-  index: number
+	mapId: MapId
+	index: number
 }
 
 export default async function PreviewCard({ mapId, index }: IPreviewCard) {
-  const config = await getMapConfig(mapId)
-  if (!config) return null
+	const config = await getMapConfig(mapId)
+	if (!config) return null
 
-  return (
-    <CustomLink
-      prefetch="auto"
-      href={`/maps/${config.id}`}
-      aria-label={`View ${config.title} interactive map`}
-      className={cn("group outline-none", {
-        "pointer-events-none opacity-75 dark:opacity-50": config.state === "Coming Soon",
-      })}
-      aria-disabled={config.state === "Coming Soon"}
-      tabIndex={config.state === "Coming Soon" ? -1 : 0}
-    >
-      <div className="flex flex-col items-start justify-center gap-4">
-        <div className="flex w-full items-center justify-center overflow-hidden rounded-md shadow-xl group-focus-visible:outline-2 group-focus-visible:outline-primary dark:shadow-none">
-          <PreviewCardImage
-            mapId={mapId}
-            title={config.title}
-            priority={index === 0}
-            className="transition-transform duration-300 will-change-transform group-focus-visible:scale-105"
-          />
-        </div>
-        <div className="flex flex-col items-start justify-center">
-          <div className="flex items-center gap-2">
-            {config.state === "Coming Soon" ? (
-              <ComingSoonBadge />
-            ) : config.state === "New" ? (
-              <NewBadge />
-            ) : null}
-            <Badge className="badge-primary-gradient dark:dark-badge-primary-gradient">
-              {config.game}
-            </Badge>
-          </div>
-          <h3 className="font-bold text-xl transition-colors group-hover:text-primary group-focus-visible:text-primary">
-            {config.title}
-          </h3>
-        </div>
-      </div>
-    </CustomLink>
-  )
+	return (
+		<CustomLink
+			href={`/maps/${config.id}`}
+			aria-label={`View ${config.title} interactive map`}
+			className={cn("group outline-none", {
+				"pointer-events-none opacity-75 dark:opacity-50": config.state === "Coming Soon",
+			})}
+			aria-disabled={config.state === "Coming Soon"}
+			tabIndex={config.state === "Coming Soon" ? -1 : 0}
+		>
+			<div className="flex flex-col items-start justify-center gap-4">
+				<div className="flex w-full items-center justify-center overflow-hidden rounded-md shadow-xl group-focus-visible:outline-2 group-focus-visible:outline-primary dark:shadow-none">
+					<PreviewCardImage
+						mapId={mapId}
+						title={config.title}
+						priority={index === 0}
+						className="transition-transform duration-300 will-change-transform group-focus-visible:scale-105"
+					/>
+				</div>
+				<div className="flex flex-col items-start justify-center">
+					<div className="flex items-center gap-2">
+						{config.state === "Coming Soon" ? (
+							<ComingSoonBadge />
+						) : config.state === "New" ? (
+							<NewBadge />
+						) : null}
+						<Badge className="badge-primary-gradient dark:dark-badge-primary-gradient">
+							{config.game}
+						</Badge>
+					</div>
+					<h3 className="font-bold text-xl transition-colors group-hover:text-primary group-focus-visible:text-primary">
+						{config.title}
+					</h3>
+				</div>
+			</div>
+		</CustomLink>
+	)
 }


### PR DESCRIPTION
We previously added an override to the `prefetch` property of the `next/link` component used within our `CustomLink` component to prevent driving up Edge Requests numbers. We are removing this to improve the performance of the application, since it is no longer a cost concern.