### PR TITLE
chore: remove @vercel/analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css"
 import type { Metadata, Viewport } from "next"
 import { GoogleAnalytics } from "@next/third-parties/google"
-import { Analytics } from "@vercel/analytics/react"
 import { Geist, Geist_Mono } from "next/font/google"
 import { HashLinkHandler } from "@/components/custom-link/custom-link"
 import Header from "@/components/header/header"
@@ -84,7 +83,6 @@ export default function RootLayout({ children }: LayoutProps) {
 						{children}
 						<Toaster richColors position="top-center" closeButton />
 					</ThemeProvider>
-					<Analytics debug={false} />
 					<HashLinkHandler />
 					<GoogleAnalytics gaId="G-2M6PMT6Z3R" />
 				</KeyboardShortcutsProvider>

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,6 @@
         "@react-email/components": "0.3.2",
         "@t3-oss/env-nextjs": "0.13.8",
         "@tanstack/react-form": "^1.23.6",
-        "@vercel/analytics": "1.5.0",
         "babel-plugin-react-compiler": "^1.0.0",
         "botid": "^1.5.6",
         "class-variance-authority": "^0.7.1",
@@ -656,8 +655,6 @@
     "@types/webpack": ["@types/webpack@5.28.5", "", { "dependencies": { "@types/node": "*", "tapable": "^2.2.0", "webpack": "^5" } }, "sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
-
-    "@vercel/analytics": ["@vercel/analytics@1.5.0", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g=="],
 
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"@react-email/components": "0.3.2",
 		"@t3-oss/env-nextjs": "0.13.8",
 		"@tanstack/react-form": "^1.23.6",
-		"@vercel/analytics": "1.5.0",
 		"babel-plugin-react-compiler": "^1.0.0",
 		"botid": "^1.5.6",
 		"class-variance-authority": "^0.7.1",


### PR DESCRIPTION
removes the `@vercel/analytics` package since we are no longer using it for our analytics.