### PR TITLE
feat: add app manifest.ts for home screen installations on mobile devices

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -4,7 +4,7 @@ import type { MetadataRoute } from 'next'
 export default function manifest(): MetadataRoute.Manifest {
 	return {
 		name: SITE_TITLE,
-		short_name: 'CodZombiesGuides',
+		short_name: 'Zombies Guides',
 		description: SITE_DESCRIPTION,
 		start_url: '/',
 		display: 'standalone',


### PR DESCRIPTION
Adds a `manifest.ts` file to the root for browsers to reference when mobile users want to install our website onto their home screens