### PR TITLE
fix(ToC): mobile table of contents not taking full screen width

### DIFF
--- a/components/table-of-contents/mobile-table-of-contents.tsx
+++ b/components/table-of-contents/mobile-table-of-contents.tsx
@@ -7,7 +7,7 @@ import { RemoveScroll } from "react-remove-scroll"
 import { cn } from "@/lib/utils"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible"
 import { Progress } from "../ui/progress"
-import { ScrollArea, ScrollBar } from "../ui/scroll-area"
+import { ScrollArea } from "../ui/scroll-area"
 
 interface MobileTableOfContentsProps {
 	headings: Heading[]
@@ -60,7 +60,6 @@ export default function MobileTableOfContents({
 									))}
 								</ul>
 							</nav>
-							<ScrollBar orientation="vertical" />
 						</ScrollArea>
 					</RemoveScroll>
 				</CollapsibleContent>


### PR DESCRIPTION
Correctly positions mobile table of contents to cover the entire screen width.

Closes [CODZG-166](codzombiesguidesteam/codzg-166-fix-mobile-table-of-contents)