### PR TITLE
update: components to use more shadcn primitives

### DIFF
--- a/components/bestiary-grid/bestiary-grid.tsx
+++ b/components/bestiary-grid/bestiary-grid.tsx
@@ -5,6 +5,7 @@ import { useFilterParams } from "@/hooks/use-filter-params"
 import { MAP_LIMIT } from "@/utils/constants"
 import { calculateSkip } from "@/utils/functions.client"
 import BestiaryCard from "../bestiary-card/bestiary-card"
+import EmptyGrid from "../empty/empty-grid"
 import GridPagination from "../grid-pagination/grid-pagination"
 import GridPaginationLoader from "../loaders/grid-pagination-loader"
 
@@ -47,9 +48,7 @@ export default function BestiaryGridClient({ zombies }: IBestiaryGridClient) {
 						<BestiaryCard key={zombie.id} zombie={zombie} zombieIndex={index} />
 					))
 				) : (
-					<p className="col-span-4 text-center text-muted-foreground">
-						No zombies found with the selected filters.
-					</p>
+					<EmptyGrid className="col-span-4" type="Zombie" />
 				)}
 			</div>
 			<Suspense fallback={<GridPaginationLoader />}>

--- a/components/empty/empty-grid.tsx
+++ b/components/empty/empty-grid.tsx
@@ -1,0 +1,26 @@
+import { Book, Brain } from "lucide-react"
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty"
+
+interface EmptyGridProps {
+	type: "Quest" | "Zombie"
+	className?: string
+	title?: string
+	description?: string
+}
+
+export default function EmptyGrid({ type, title, description, className }: EmptyGridProps) {
+	return (
+		<Empty className={className}>
+			<EmptyHeader>
+				<EmptyMedia variant="icon" className="text-primary">
+					{type === "Quest" ? <Book /> : <Brain />}
+				</EmptyMedia>
+				<EmptyTitle>{title || `No ${type}s Found`}</EmptyTitle>
+				<EmptyDescription>
+					{description ||
+						`No ${type.toLowerCase()}s match the selected filters. Reset the filters or select different filters.`}
+				</EmptyDescription>
+			</EmptyHeader>
+		</Empty>
+	)
+}

--- a/components/quest-grid/quest-grid.tsx
+++ b/components/quest-grid/quest-grid.tsx
@@ -9,6 +9,7 @@ import QuestPreviewCard from "@/components/quest-preview-card/quest-preview-card
 import { useFilterParams } from "@/hooks/use-filter-params"
 import { MAP_LIMIT } from "@/utils/constants"
 import { calculateSkip } from "@/utils/functions.client"
+import EmptyGrid from "../empty/empty-grid"
 
 interface IQuestGridClient {
 	quests: (Omit<MainQuest, "content"> | Omit<SideQuest, "content">)[]
@@ -24,7 +25,7 @@ export default function QuestGridClient({ quests }: IQuestGridClient) {
 
 	if (difficultyParams.length > 0) {
 		filteredQuests = filteredQuests.filter(quest => {
-			if (Predicate.hasProperty(quest, "difficulty") && Predicate.isString(quest.difficulty)) {
+			if (!Predicate.hasProperty(quest, "title") && quest.difficulty) {
 				return difficultyParams.includes(quest.difficulty.toLowerCase())
 			}
 			return false
@@ -55,9 +56,7 @@ export default function QuestGridClient({ quests }: IQuestGridClient) {
 						<QuestPreviewCard key={quest.id} quest={quest} questIndex={index} />
 					))
 				) : (
-					<p className="col-span-4 text-center text-muted-foreground">
-						No quests found with the selected filters.
-					</p>
+					<EmptyGrid type="Quest" className="col-span-4" />
 				)}
 			</div>
 			<Suspense fallback={<GridPaginationLoader />}>

--- a/components/shortcut/shortcut.tsx
+++ b/components/shortcut/shortcut.tsx
@@ -1,5 +1,6 @@
 import { cva } from "class-variance-authority"
 import { Array as Arr } from "effect"
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
 import { cn } from "@/lib/utils"
 
 interface ShortcutProps {
@@ -9,7 +10,7 @@ interface ShortcutProps {
 	size?: "sm" | "md" | "lg"
 }
 
-const shortvutVariants = cva(
+const shortcutVariants = cva(
 	"inline-flex items-center justify-center font-mono font-medium rounded border transition-colors",
 	{
 		variants: {
@@ -42,12 +43,15 @@ export default function Shortcut({
 	const shortcutArray = Arr.ensure(shortcuts)
 
 	return (
-		<span className="inline-flex items-center gap-1">
+		<KbdGroup>
 			{shortcutArray.map((shortcut, index) => (
-				<span key={`${shortcut}-${index + 1}`} className="inline-flex items-center gap-1">
-					<kbd className={cn(shortvutVariants({ variant, size }), className)}>{shortcut}</kbd>
-				</span>
+				<Kbd
+					key={`${shortcut}-${index + 1}`}
+					className={cn(shortcutVariants({ variant, size }), className)}
+				>
+					{shortcut}
+				</Kbd>
 			))}
-		</span>
+		</KbdGroup>
 	)
 }

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "flex shrink-0 items-center justify-center mb-2 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/components/ui/kbd.tsx
+++ b/components/ui/kbd.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils"
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+	return (
+		<kbd
+			data-slot="kbd"
+			className={cn(
+				"pointer-events-none inline-flex h-5 w-fit min-w-5 select-none items-center justify-center gap-1 rounded-sm bg-muted px-1 font-medium font-sans text-muted-foreground text-xs",
+				"[&_svg:not([class*='size-'])]:size-3",
+				className,
+			)}
+			{...props}
+		/>
+	)
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<kbd
+			data-slot="kbd-group"
+			className={cn("inline-flex items-center gap-1", className)}
+			{...props}
+		/>
+	)
+}
+
+export { Kbd, KbdGroup }


### PR DESCRIPTION
Adds the `Kbd` and `Empty` shadcn components for a consistent and accessible default for shortcuts and empty states.