### PR TITLE
update: contact email to use Resends new inbound feature

### DIFF
--- a/data/email.ts
+++ b/data/email.ts
@@ -78,7 +78,7 @@ export const sendContactEmail = (props: EmailProps) =>
 		yield* sendEmail({
 			from: `${props.name} <contact@codzombiesguides.com>`,
 			replyTo: props.email,
-			to: "codzombiesguidesteam@gmail.com",
+			to: "contact@codzombiesguides.com",
 			subject: "Contact Form Submission",
 			text: props.message,
 		})

--- a/emails/policy-update-email.tsx
+++ b/emails/policy-update-email.tsx
@@ -87,7 +87,7 @@ export default function PrivacyPolicyUpdateEmail({ unsubscribeUrl }: { unsubscri
 
 							<Text className="mb-[32px] text-[#333] text-[16px] leading-[24px]">
 								If you have any questions about our Privacy Policy, please contact our team at
-								codzombiesguidesteam@gmail.com. We value your trust and are committed to protecting
+								contact@codzombiesguides.com. We value your trust and are committed to protecting
 								your privacy.
 							</Text>
 

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -20,7 +20,7 @@ export const GLOBAL_OG_PROPS: Partial<Metadata> = {
 		siteName: SITE_TITLE,
 		locale: "en_US",
 		type: "website",
-		emails: ["codzombiesguidesteam@gmail.com"],
+		emails: ["contact@codzombiesguides.com"],
 	},
 }
 export const ROUTES = [


### PR DESCRIPTION
Updates our contact form and open graph `email` to point to our verified custom domain on `Resend`. This uses their newly annouced inbound feature which allows us to view support emails in their UI.