### PR TITLE
feat: create PageRuntime and APIRuntime for layer construction

### DIFF
--- a/app/(main)/[game]/[map]/page.tsx
+++ b/app/(main)/[game]/[map]/page.tsx
@@ -21,7 +21,7 @@ import {
 	getMainQuests,
 	type MainQuest,
 } from "@/data/main-quests"
-import { FileSystemLayer } from "@/lib/layers"
+import { PageRuntime } from "@/lib/layers"
 import { cn } from "@/lib/utils"
 import { useMDXComponents } from "@/mdx-components"
 import { GLOBAL_OG_PROPS, IN_DEVELOPMENT } from "@/utils/constants"
@@ -204,9 +204,8 @@ export default async function MainQuestPage({ params }: PageProps<"/[game]/[map]
 		Effect.withLogSpan("main_quest_page"),
 		Effect.tapError(Effect.logError),
 		Effect.catchAll(_error => Effect.succeed(null)),
-		Effect.provide(FileSystemLayer),
 		Effect.ensureErrorType<never>(),
-		Effect.runPromise,
+		PageRuntime.runPromise,
 	)
 }
 

--- a/app/(main)/side-quests/[game]/[map]/[id]/page.tsx
+++ b/app/(main)/side-quests/[game]/[map]/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
 	getSideQuests,
 	type SideQuest,
 } from "@/data/side-quests"
+import { PageRuntime } from "@/lib/layers"
 import { cn } from "@/lib/utils"
 import { useMDXComponents } from "@/mdx-components"
 import { PageNotFoundError } from "@/types/errors"
@@ -28,7 +29,6 @@ import {
 	getServerUrl,
 } from "@/utils/functions"
 import QuestNotFoundPage from "./not-found"
-import { FileSystemLayer } from "@/lib/layers"
 
 export const generateStaticParams = () => {
 	const quests = getSideQuests()
@@ -217,9 +217,8 @@ export default async function SideQuestPage({
 			PageNotFoundError: _error => Effect.succeed(<QuestNotFoundPage />),
 			UnknownException: _error => Effect.succeed(null),
 		}),
-		Effect.provide(FileSystemLayer),
 		Effect.ensureErrorType<never>(),
-		Effect.runPromise,
+		PageRuntime.runPromise,
 	)
 }
 

--- a/app/api/newsletter/subscribe/route.ts
+++ b/app/api/newsletter/subscribe/route.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { type NextRequest, NextResponse } from "next/server"
 import { subscribeEmail } from "@/data/email"
-import { Email } from "@/lib/services/emails"
+import { APIRuntime } from "@/lib/layers"
 import { verifyToken } from "@/utils/functions"
 
 export async function GET(req: NextRequest) {
@@ -51,7 +51,6 @@ export async function GET(req: NextRequest) {
 			},
 		}),
 		Effect.ensureErrorType<never>(),
-		Effect.provide(Email.Default),
-		Effect.runPromise,
+		APIRuntime.runPromise,
 	)
 }

--- a/app/api/newsletter/unsubscribe/route.ts
+++ b/app/api/newsletter/unsubscribe/route.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { type NextRequest, NextResponse } from "next/server"
 import { unsubscribeEmail } from "@/data/email"
-import { Email } from "@/lib/services/emails"
+import { APIRuntime } from "@/lib/layers"
 import { verifyToken } from "@/utils/functions"
 
 export async function GET(req: NextRequest) {
@@ -60,7 +60,6 @@ export async function GET(req: NextRequest) {
 			},
 		}),
 		Effect.ensureErrorType<never>(),
-		Effect.provide(Email.Default),
-		Effect.runPromise,
+		APIRuntime.runPromise,
 	)
 }

--- a/components/grid-pagination/grid-pagination.tsx
+++ b/components/grid-pagination/grid-pagination.tsx
@@ -25,6 +25,7 @@ export default function GridPagination({ data }: IGridPagination) {
 		// Helper function to add page button
 		const addPageButton = (pageNum: number) => (
 			<Button
+				key={pageNum}
 				size="sm"
 				variant="outline"
 				aria-current={currentPage === pageNum ? "page" : undefined}

--- a/data/actions.ts
+++ b/data/actions.ts
@@ -3,66 +3,57 @@ import { Effect } from "effect"
 import { requestSubscribe, requestUnsubscribe, sendContactEmail } from "@/data/email"
 import { submitFeedback } from "@/data/feedback"
 import { createAction } from "@/lib/action-helpers"
-import { Email } from "@/lib/services/emails"
+import { APIRuntime } from "@/lib/layers"
 import {
 	ContactFormSchema,
 	FeedbackFormSchema,
 	NewsletterFormSchema,
 } from "@/utils/validation-schemas"
 
-export const subscribeToNewsletter = createAction(
-	NewsletterFormSchema,
-	async ({ email }) => {
-		return await requestSubscribe(email).pipe(
-			Effect.withLogSpan("subscribe_to_newsletter_action"),
-			Effect.timeout("10 seconds"),
-			Effect.tapError(Effect.logError),
-			Effect.catchTags({
-				ContactExistsError: error =>
-					Effect.succeed({
-						success: false,
-						message: error.message,
-					}),
-			}),
-			Effect.catchAll(_error =>
+export const subscribeToNewsletter = createAction(NewsletterFormSchema, async ({ email }) => {
+	return await requestSubscribe(email).pipe(
+		Effect.withLogSpan("subscribe_to_newsletter_action"),
+		Effect.timeout("10 seconds"),
+		Effect.tapError(Effect.logError),
+		Effect.catchTags({
+			ContactExistsError: error =>
 				Effect.succeed({
 					success: false,
-					message:
-						"Subscribe request failed due to a technical issue on our end. Please try again.",
+					message: error.message,
 				}),
-			),
-			Effect.provide(Email.Default),
-			Effect.runPromise,
-		)
-	},
-)
+		}),
+		Effect.catchAll(_error =>
+			Effect.succeed({
+				success: false,
+				message: "Subscribe request failed due to a technical issue on our end. Please try again.",
+			}),
+		),
+		APIRuntime.runPromise,
+	)
+})
 
-export const unsubscribeFromNewsletter = createAction(
-	NewsletterFormSchema,
-	async ({ email }) => {
-		return await requestUnsubscribe(email).pipe(
-			Effect.withLogSpan("unsubscribe_from_newsletter_action"),
-			Effect.timeout("10 seconds"),
-			Effect.tapError(Effect.logError),
-			Effect.catchTags({
-				ContactNotFoundError: error =>
-					Effect.succeed({
-						success: false,
-						message: error.message,
-					}),
-			}),
-			Effect.catchAll(_error =>
+export const unsubscribeFromNewsletter = createAction(NewsletterFormSchema, async ({ email }) => {
+	return await requestUnsubscribe(email).pipe(
+		Effect.withLogSpan("unsubscribe_from_newsletter_action"),
+		Effect.timeout("10 seconds"),
+		Effect.tapError(Effect.logError),
+		Effect.catchTags({
+			ContactNotFoundError: error =>
 				Effect.succeed({
 					success: false,
-					message:
-						"Unsubscribe request failed due to a technical issue on our end. Please try again.",
+					message: error.message,
 				}),
-			),
-			Effect.provide(Email.Default),
-			Effect.runPromise,
-		)
-	},
-)
+		}),
+		Effect.catchAll(_error =>
+			Effect.succeed({
+				success: false,
+				message:
+					"Unsubscribe request failed due to a technical issue on our end. Please try again.",
+			}),
+		),
+		APIRuntime.runPromise,
+	)
+})
 
 export const submitFeedbackForm = createAction(FeedbackFormSchema, async parsedInput => {
 	return await submitFeedback(parsedInput).pipe(
@@ -92,7 +83,6 @@ export const submitContactForm = createAction(ContactFormSchema, async parsedInp
 					"Contact form submission failed due to a technical issue on our end. Please try again.",
 			}),
 		),
-		Effect.provide(Email.Default),
-		Effect.runPromise,
+		APIRuntime.runPromise,
 	)
 })

--- a/lib/layers.ts
+++ b/lib/layers.ts
@@ -1,5 +1,8 @@
-import { Layer } from "effect"
 import { Path } from "@effect/platform"
 import { BunFileSystem } from "@effect/platform-bun"
+import { Layer, ManagedRuntime } from "effect"
+import { Email } from "./services/emails"
 
-export const FileSystemLayer = Layer.merge(BunFileSystem.layer, Path.layer)
+const FileSystemLayer = Layer.merge(BunFileSystem.layer, Path.layer)
+export const PageRuntime = ManagedRuntime.make(FileSystemLayer)
+export const APIRuntime = ManagedRuntime.make(Email.Default)


### PR DESCRIPTION
Create a `PageRuntime` and `APIRuntime` for handling layer construction and re-useability across the application, ensuring live implementations of dependencies aren't being re-instantiated multiple times to get the full advantage of the internal `Layer.memoMap`.