### PR TITLE
fix: zombie page missing game context & wrong `firstAppearIn` map value

### DIFF
--- a/app/(main)/bestiary/[id]/page.tsx
+++ b/app/(main)/bestiary/[id]/page.tsx
@@ -93,7 +93,6 @@ const ZombiePage = Effect.fn("ZombiePage")(function* ({ params }: PageProps<"/be
 		onNone: () => undefined,
 		onSome: game => convertIdToGameKey(game.id),
 	})
-	console.log(mostRecentGame)
 	const firstAppearIn = Arr.get(zombie.maps, 0)
 
 	const speedProgress = () => {

--- a/data/games.ts
+++ b/data/games.ts
@@ -32,8 +32,13 @@ export const getGameByKey = (key: GameKey): Game => gameRegistry[key]
  * convertIdToGameKey("black-ops-1") // "blackOps1"
  */
 export const convertIdToGameKey = (id: string): GameKey => {
-	const camelCaseId = id.replace(/-([a-z0-9])/g, (_, letter) => letter.toUpperCase())
-	return camelCaseId as GameKey
+	const gameKey = id.replace(/-([a-z0-9])/g, (_, letter) => letter.toUpperCase())
+	const isValidGameKey = gameKey in gameRegistry
+	if (!isValidGameKey) {
+		throw new Error(`Invalid game key: ${gameKey}`)
+	}
+
+	return gameKey as GameKey
 }
 
 const gameRegistry = {

--- a/tests/data/games.test.ts
+++ b/tests/data/games.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from "vitest"
+import { convertIdToGameKey } from "../../data/games"
+
+describe("convertIdToGameKey", () => {
+	it("should convert a game ID to a game key", ({ expect }) => {
+		expect(convertIdToGameKey("black-ops-1")).toBe("blackOps1")
+		expect(convertIdToGameKey("black-ops-cold-war")).toBe("blackOpsColdWar")
+	})
+
+	it("should throw an error for invalid game IDs", ({ expect }) => {
+		expect(() => convertIdToGameKey("invalid-game-id")).toThrowError(
+			"Invalid game key: invalidGameId",
+		)
+	})
+})

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -1,7 +1,6 @@
 import type { DurationInput } from "effect/Duration"
 import type { Heading } from "@/components/table-of-contents/table-of-contents"
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto"
-import { FileSystem, Path } from "@effect/platform"
 import { Duration, Effect, Number as Num, Option, Redacted } from "effect"
 import { files } from "@/data/last-modified.json"
 import { env } from "@/env"


### PR DESCRIPTION
Fixes https://github.com/PlagueFPS/cod-zombies/issues/56

Passes the correct `Game` context to the `AmmoModTooltip` for the dedicated zombie page, and also addresses a slient bug that was choosing the most recent map for the `firstAppearIn` value instead of the first map.