### PR TITLE
update(guides): add item spawn note to Dust to Dust main quest

### DIFF
--- a/content/main-quests/dust-to-dust.mdx
+++ b/content/main-quests/dust-to-dust.mdx
@@ -224,6 +224,8 @@ throw a **Molotov** at the foot to burn off the skin, revealing the **Human Bone
 <RichImage image="/content/ashes-of-the-damned/aotd-hanging-body.webp" caption="Burned hanging body, right of the Ryden 45K wall buy" />
 <RichImage image="/content/ashes-of-the-damned/aotd-human-bones.webp" caption="Human Bones from burning off the skin of the hanging body" />
 
+> There is a static spawn for the **Molotov** outside of the **Garage** in **Ashwood**, and a **Combat Axe** spawn in the kitchen of the **Diner** at **Exit 115**.
+
 ### Mysterious Limb
 > Before you can obtain this item you'll need to have upgraded **Ol' Tessie** with the **Abomination Carcass** to gain the **Beam Attack** ability.
 
@@ -439,7 +441,8 @@ middle of the arena. This will expose a giant weak point, which if you ram into 
 <RichImage image="/content/ashes-of-the-damned/aotd-phase-1.webp" caption="Phase 1" />
 
 Rinse and repeat this process until **Veytharion** goes immune and start spinning like a bay-blade. This is the phase transition period, where you will need to wait for
-him to launch a purple beam of light onto the arena, which you need to drive through to supercharge **Ol' Tessie**, and then ram into **Veytharion** to knock off his shield.
+him to launch a purple beam of light onto the arena, or ram into him to force him to spawn one, which you need to drive through to supercharge **Ol' Tessie**, and then ram
+into **Veytharion** to knock off his shield.
 
 <RichImage image="/content/ashes-of-the-damned/aotd-immune-phase.webp" caption="Immune Phase Transition" />
 
@@ -464,7 +467,7 @@ Congratulations, you have completed the **Ashes of the Damned** main quest: **Du
 
 ## Video Guides
 
-## Solo Guide by MZC
+### Solo Guide by MZC
 <YoutubeEmbed videoLink="https://youtu.be/DykVCACVJE4?si=ny0PdU1Xf5f003_P" />
 
 ### Co-op Guide by NoahJ456


### PR DESCRIPTION
Adds a note to the `Human Bones` section of the `Dust to Dust` main quest about the location of static spawns for molotovs and combat axes