### PR TITLE
update(guides): add important Exit 115 challenge tip for Dust To Dust

### DIFF
--- a/content/main-quests/dust-to-dust.mdx
+++ b/content/main-quests/dust-to-dust.mdx
@@ -365,8 +365,9 @@ Head to **Exit 115** and wait for colored lightning to strike, and while infused
 
 Once frozen, you must revive and lure three special zombies into their respective lightning strike. In no particular order here is how to revive each zombie:
 
-> It is highly unlikely, that you will be able to complete this challenge in a single time freeze if you are not in a group, which is fine. You'll just need to wait a couple of rounds
-for the lightning to strike again, and shoot the clock with another infused shot to continue from where you left off.
+> It is highly unlikely, that you will be able to complete this challenge in a single time freeze if you are not in a group, which is fine. You'll just need to use the **DG-2 Turret**
+on **Ol' Tessie** to shock three sparking deactivated light posts in the **Exit 115** area, only one will be sparking at a time. There is one next to the **Gas Station** and one near each entrance
+to the area.
 
 #### Waitress
 Head inside the **Diner** and punch the cash register with <PerkTooltip perkKey="meleeMacchiato" game="blackOps7" /> to revive the **Waitress**. Then run up to the roof to lure


### PR DESCRIPTION
Adds a crucial tip for saving time during the `Exit 115` challenge step of the `Dust To Dust` main quest.