### PR TITLE
update(guides): add note about unlocking Cursed to Dust To Dust main quest

### DIFF
--- a/content/main-quests/dust-to-dust.mdx
+++ b/content/main-quests/dust-to-dust.mdx
@@ -472,6 +472,9 @@ immediately when it gets destroyed, even using field upgrades if you have to, an
 
 <RichImage image="/content/ashes-of-the-damned/aotd-ending.webp" caption="Ending Cutscene" />
 
+> Make sure to press **CONTINUE** if this is your first time beating the main quest, and interact with the artifact floating by the dock in **Blackwater Lake** to unlock
+the ability to equip relics in the **Cursed Mode**.
+
 Congratulations, you have completed the **Ashes of the Damned** main quest: **Dust To Dust**!
 
 ## Video Guides


### PR DESCRIPTION
Adds note about the artifact found only after completing the main quest and continuing to unlock the ability to equip relics in the Cursed mode.