### PR TITLE
fix(perks): wrong augment being assigned to Melee Macchiato

### DIFF
--- a/content/main-quests/dust-to-dust.mdx
+++ b/content/main-quests/dust-to-dust.mdx
@@ -17,7 +17,6 @@ the **Shadowsmiths**, while also restoring the souls of our characters.
 
 - [Necrofluid Gauntlet](#step-3-obtain-the-necrofluid-gauntlet)
 - <PerkTooltip perkKey="wispTea" />
-- <PerkTooltip perkKey="meleeMacchiato" game="blackOps7" />
 - Stun Grenades
 
 ## Recommended Loadouts
@@ -356,7 +355,6 @@ you will have completed this challenge.
 > Do **NOT** use the **Raygun** to input the code as its splash damage will hit multiple buttons at once, potentially failing the challenge, and forcing you to start over.
 
 ### Exit 115 Challenge
-> Before doing this challenge, you must have <PerkTooltip perkKey="meleeMacchiato" game="blackOps7" /> equipped.
 
 Head to **Exit 115** and wait for colored lightning to strike, and while infused with **Aether Energy**, shoot the clock on the roof of the **Service Station** with the
 **Necrofluid Gauntlet** to freeze time for one minute.
@@ -370,8 +368,7 @@ on **Ol' Tessie** to shock three sparking deactivated light posts in the **Exit 
 to the area.
 
 #### Waitress
-Head inside the **Diner** and punch the cash register with <PerkTooltip perkKey="meleeMacchiato" game="blackOps7" /> to revive the **Waitress**. Then run up to the roof to lure
-her into the blue lightning strike.
+Head inside the **Diner** and melee the cash register to revive the **Waitress**. Then run up to the roof to lure her into the blue lightning strike.
 
 <RichImage image="/content/ashes-of-the-damned/aotd-diner-cash-register.webp" caption="Cash Register" />
 

--- a/data/perks.ts
+++ b/data/perks.ts
@@ -435,7 +435,7 @@ const perkRegistry = {
 					"mochaMaul",
 					"stickNMove",
 					"strengthTraining",
-					"hiddenImpact",
+					"mugging",
 					"baristaBrawl",
 				],
 			},


### PR DESCRIPTION
Fixes https://github.com/PlagueFPS/cod-zombies/issues/75

`Hidden Impact` augment was being assigned to the black ops 7 variant of `Melee Macchiato` but it was renamed to `Mugging` in black ops 7, which we treat as an entirely new augment.