### PR TITLE
fix(guides): inaccurate caption for turn to ashes headphone location

### DIFF
--- a/content/side-quests/turn-to-ashes.mdx
+++ b/content/side-quests/turn-to-ashes.mdx
@@ -8,7 +8,7 @@ with vocals by [Elena Siegman](https://www.elenasiegman.com/).
 ## Headphones Locations
 
 <RichImage image="/content/ashes-of-the-damned/aotd-turn-to-ashes-first-headphones.webp" caption="Security Room (Janus Towers Plaza) - on top of one of the servers in the center of the room" />
-<RichImage image="/content/ashes-of-the-damned/aotd-turn-to-ashes-second-headphones.webp" caption="Judgement Square (Ashwood) - on one of the broken beams above the Shadow SDK wall buy" />
+<RichImage image="/content/ashes-of-the-damned/aotd-turn-to-ashes-second-headphones.webp" caption="Judgement Square (Ashwood) - on one of the broken beams above the VS Recon wall buy" />
 <RichImage image="/content/ashes-of-the-damned/aotd-turn-to-ashes-third-headphones.webp" caption="Exit 115 - in the passenger seat of the jeep near the Gas Station" />
 
 ## Official Song & Lyrics


### PR DESCRIPTION
Fixes the inaccurate reference to the Shadow SK sniper, when it is actually the VS Recon