### PR TITLE
update(workflow): ensure workflow reruns on reopened PRs

### DIFF
--- a/.github/workflows/update-last-modified.yml
+++ b/.github/workflows/update-last-modified.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - "content/**/*.mdx"
-    types: [opened, synchronize]
+    types: [reopened, opened, synchronize]
 
 jobs:
   update-last-modified:


### PR DESCRIPTION
Ensures the `update-last-modified` workflow runs during re-openings of PRs to ensure it doesn't rewrite history.