### PR TITLE
fix: mobile table of contents z-index

### DIFF
--- a/components/table-of-contents/mobile-table-of-contents.tsx
+++ b/components/table-of-contents/mobile-table-of-contents.tsx
@@ -25,7 +25,7 @@ export default function MobileTableOfContents({
 	const [open, setOpen] = useState(false)
 
 	return (
-		<div className="sticky top-16 z-10 block w-full bg-background/90 backdrop-blur-xs supports-backdrop-filter:backdrop-blur-xs xl:hidden">
+		<div className="sticky top-16 z-50 block w-full bg-background/90 backdrop-blur-xs supports-backdrop-filter:backdrop-blur-xs xl:hidden">
 			<Collapsible open={open} onOpenChange={setOpen} className="group/collapsible">
 				<CollapsibleTrigger asChild>
 					<div className="relative flex w-full flex-col items-center p-3">


### PR DESCRIPTION
Fixes the z-index for the mobile table of contents. Guide images were appearing over it due to bad content layering.