### PR TITLE
fix: map params structure to use comma-separated values

### DIFF
--- a/components/interactive-map/map-sidebar.tsx
+++ b/components/interactive-map/map-sidebar.tsx
@@ -5,7 +5,7 @@ import { Option } from "effect"
 import { ChevronDown, MapPin } from "lucide-react"
 import Image from "next/image"
 import { useParams, useRouter } from "next/navigation"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useMapSearchParams } from "@/hooks/use-map-search-params"
 import { cn } from "@/lib/utils"
 import { capitalize } from "@/utils/functions.client"
@@ -45,8 +45,15 @@ interface IMapSidebar {
 }
 
 export default function MapSidebar({ groups, maps, mapLayers }: IMapSidebar) {
-	const { clearParam, toggleExcludeParam, createParams, layerParam, isIncluded } =
-		useMapSearchParams()
+	const {
+		clearParam,
+		toggleExcludeParam,
+		createParams,
+		layerParam,
+		isIncluded,
+		convertIncludeToExclude,
+		updateURLParams,
+	} = useMapSearchParams()
 	const mapMarkers = Option.isSome(layerParam)
 		? (mapLayers.find(layer => layer.id === layerParam.value)?.markers ?? [])
 		: (mapLayers.at(0)?.markers ?? [])
@@ -54,6 +61,10 @@ export default function MapSidebar({ groups, maps, mapLayers }: IMapSidebar) {
 	const [toggle, setToggle] = useState<"All" | "None">("None")
 	const router = useRouter()
 	const currentMap = capitalize(String(id))
+
+	useEffect(() => {
+		convertIncludeToExclude(mapMarkers)
+	}, [convertIncludeToExclude, mapMarkers])
 
 	const handleCheckedChange = (type: string) => {
 		toggleExcludeParam(type)
@@ -69,16 +80,28 @@ export default function MapSidebar({ groups, maps, mapLayers }: IMapSidebar) {
 
 		const params = createParams()
 		if (params.size > 0) {
+
 			if (params.has("exclude")) {
-				const excludeParams = params.getAll("exclude")
-				const includeParams = mapMarkers.filter(
-					marker => !excludeParams.includes(marker.type || marker.id),
-				)
-				params.delete("exclude")
-				includeParams.forEach(marker => {
-					params.append("include", marker.type || marker.id)
+				const excludeParams = Option.match(Option.fromNullable(params.get("exclude")), {
+					onSome: value => {
+						const decoded = decodeURIComponent(value)
+						return decoded.split(",").map(v => v.trim()).filter(v => v.length > 0)
+					},
+					onNone: (): string[] => [],
 				})
 
+				const includedIds = new Set<string>()
+				const includeParams = mapMarkers.filter(marker => {
+					const id = marker.type || marker.id
+					if (!excludeParams.includes(id) && !includedIds.has(id)) {
+						includedIds.add(id)
+						return true
+					}
+					return false
+				})
+
+				params.delete("exclude")
+				params.append("include", includeParams.map(marker => marker.type || marker.id).join(","))
 				return `${window.location.origin}/maps/${id}?${params.toString()}`
 			}
 
@@ -91,18 +114,23 @@ export default function MapSidebar({ groups, maps, mapLayers }: IMapSidebar) {
 	const toggleFilters = () => {
 		if (toggle === "All") {
 			setToggle("None")
-			return clearParam("exclude")
+			clearParam("exclude")
+			return
 		}
 
-		const newValues: string[] = []
+		const allMarkerIds = Array.from(
+			new Set(mapMarkers.map(marker => marker.type || marker.id)),
+		)
 
-		for (const category in groups) {
-			groups[category as MarkerCategory].forEach(value => {
-				newValues.push(value)
-			})
+		const params = createParams()
+		params.delete("include")
+		params.delete("exclude")
+
+		if (allMarkerIds.length > 0) {
+			params.append("exclude", allMarkerIds.join(","))
 		}
 
-		toggleExcludeParam(newValues)
+		updateURLParams(params)
 		setToggle("All")
 	}
 

--- a/hooks/use-map-search-params.ts
+++ b/hooks/use-map-search-params.ts
@@ -1,3 +1,4 @@
+import type { MapMarker } from "@/map-configs/markers"
 import { Array as Arr, Option } from "effect"
 import { useSearchParams } from "next/navigation"
 
@@ -22,12 +23,26 @@ interface MapSearchParamsResult {
 	toggleExcludeParam: (value: string | string[]) => string[]
 	/** Checks if a type should be included based on current filters */
 	isIncluded: (type: string) => boolean
+	/** Converts include filter to exclude filter */
+	convertIncludeToExclude: (markers: MapMarker[]) => void
 }
 
 export const useMapSearchParams = (): MapSearchParamsResult => {
 	const searchParams = useSearchParams()
-	const includeParams = searchParams.getAll("include")
-	const excludeParams = searchParams.getAll("exclude")
+	const includeParams = Option.match(Option.fromNullable(searchParams.get("include")), {
+		onSome: value => {
+			const decodeValue = decodeURIComponent(value)
+			return decodeValue.split(",")
+		},
+		onNone: (): string[] => [],
+	})
+	const excludeParams = Option.match(Option.fromNullable(searchParams.get("exclude")), {
+		onSome: value => {
+			const decodeValue = decodeURIComponent(value)
+			return decodeValue.split(",")
+		},
+		onNone: (): string[] => [],
+	})
 	const layerParam = Option.fromNullable(searchParams.get("layer"))
 
 	const updateURLParams = (params: URLSearchParams) => {
@@ -47,9 +62,7 @@ export const useMapSearchParams = (): MapSearchParamsResult => {
 			? currentValues.filter(v => !value.includes(v))
 			: [...currentValues, ...valuesToToggle]
 
-		newValues.forEach(v => {
-			params.append(paramName, v)
-		})
+		params.append(paramName, newValues.join(","))
 		updateURLParams(params)
 
 		return newValues
@@ -79,6 +92,30 @@ export const useMapSearchParams = (): MapSearchParamsResult => {
 		return (includeParams.length === 0 && !isExcluded) || (isIncluded && !isExcluded)
 	}
 
+	const convertIncludeToExclude = (markers: MapMarker[]) => {
+		const params = createParams()
+		if (params.has("include")) {
+			const includeArray = includeParams.filter(v => v.length > 0)
+			const excludedIds = new Set<string>()
+			const excludedMarkers = markers
+				.filter(marker => {
+					const id = marker.type || marker.id
+					if (!includeArray.includes(id) && !excludedIds.has(id)) {
+						excludedIds.add(id)
+						return true
+					}
+					return false
+				})
+				.map(marker => marker.type || marker.id)
+
+			params.delete("include")
+			if (excludedMarkers.length > 0) {
+				params.append("exclude", excludedMarkers.join(","))
+			}
+			updateURLParams(params)
+		}
+	}
+
 	return {
 		searchParams,
 		includeParams,
@@ -90,5 +127,6 @@ export const useMapSearchParams = (): MapSearchParamsResult => {
 		toggleExcludeParam,
 		clearParam,
 		isIncluded,
+		convertIncludeToExclude,
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/PlagueFPS/cod-zombies/issues/98

Uses comma-separated values instead of appending the same parameter with additional values for URL clarity while maintaining the same functionality.