### PR TITLE
chore: remove minimumTTL config for images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,127 +1,125 @@
-import type { NextConfig } from "next";
-import createMDX from "@next/mdx";
-import { withBotId } from "botid/next/config";
+import type { NextConfig } from "next"
+import createMDX from "@next/mdx"
+import { withBotId } from "botid/next/config"
 
 const nextConfig: NextConfig = {
-  experimental: {
-    serverComponentsHmrCache: true,
-    browserDebugInfoInTerminal: true,
-    mdxRs: true,
-    turbopackFileSystemCacheForDev: true,
-  },
-  // Without this, builds will fail with an OOM (out of memory) failure due to excessive memory usage.
-  outputFileTracingExcludes: {
-    "/*": ["public/**", "scripts/**", "tests/**"],
-  },
-  reactCompiler: true,
-  typedRoutes: true,
-  allowedDevOrigins: ["10.0.0.*"],
-  logging: {
-    fetches: {
-      hmrRefreshes: true,
-      fullUrl: true,
-    },
-  },
-  images: {
-    formats: ["image/webp"],
-    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
-    qualities: [75, 100],
-    minimumCacheTTL: 31536000, // 1 year in seconds
-  },
-  // biome-ignore lint/suspicious/useAwait: redirects must be async
-  async redirects() {
-    return [
-      {
-        source: "/side-quests/black-ops-6/reckoning/c-a-s-t-e-r-turret-upgrade",
-        destination: "/side-quests/black-ops-6/reckoning/caster-turret-upgrade",
-        permanent: true,
-      },
-      {
-        source: "/side-quests/black-ops-6/shattered-veil/s-a-m-trap-unlock",
-        destination: "/side-quests/black-ops-6/shattered-veil/sam-trap-unlock",
-        permanent: true,
-      },
-      {
-        source: "/bestiary/s-a-m",
-        destination: "/bestiary/sam",
-        permanent: true,
-      },
-      {
-        source: "/bestiary/kransy-soldat",
-        destination: "/bestiary/krasny-soldat",
-        permanent: true,
-      },
-      {
-        source: "/bestiary/the-corruputed-keeper",
-        destination: "/bestiary/the-corrupted-keeper",
-        permanent: true,
-      },
-      {
-        source: "/side-quests/black-ops-6/reckoning/free-1500-points",
-        destination: "/side-quests/black-ops-6/reckoning/paintings",
-        permanent: true,
-      },
-      {
-        source: "/black-ops-1",
-        destination: "/?game=black-ops-1",
-        permanent: true,
-      },
-      {
-        source: "/black-ops-2",
-        destination: "/?game=black-ops-2",
-        permanent: true,
-      },
-      {
-        source: "/black-ops-3",
-        destination: "/?game=black-ops-3",
-        permanent: true,
-      },
-      {
-        source: "/black-ops-4",
-        destination: "/?game=black-ops-4",
-        permanent: true,
-      },
-      {
-        source: "/black-ops-cold-war",
-        destination: "/?game=black-ops-cold-war",
-        permanent: true,
-      },
-      {
-        source: "/black-ops-6",
-        destination: "/?game=black-ops-6",
-        permanent: true,
-      },
-      {
-        source: "/side-quests/black-ops-6",
-        destination: "/side-quests?game=black-ops-6",
-        permanent: true,
-      },
-      {
-        source: "/side-quests/black-ops-6/liberty-falls",
-        destination: "/side-quests?map=liberty-falls",
-        permanent: true,
-      },
-      {
-        source: "/side-quests/black-ops-6/terminus",
-        destination: "/side-quests?map=terminus",
-        permanent: true,
-      },
-      {
-        source: "/side-quests/black-ops-6/citadelle-des-morts",
-        destination: "/side-quests?map=citadelle-des-morts",
-        permanent: true,
-      },
-      {
-        source: "/side-quests/black-ops-6/the-tomb",
-        destination: "/side-quests?map=the-tomb",
-        permanent: true,
-      },
-    ];
-  },
-};
+	experimental: {
+		serverComponentsHmrCache: true,
+		browserDebugInfoInTerminal: true,
+		mdxRs: true,
+		turbopackFileSystemCacheForDev: true,
+	},
+	// Without this, builds will fail with an OOM (out of memory) failure due to excessive memory usage.
+	outputFileTracingExcludes: {
+		"/*": ["public/**", "scripts/**", "tests/**"],
+	},
+	reactCompiler: true,
+	typedRoutes: true,
+	logging: {
+		fetches: {
+			hmrRefreshes: true,
+			fullUrl: true,
+		},
+	},
+	images: {
+		formats: ["image/webp"],
+		deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+		qualities: [75, 100],
+	},
+	// biome-ignore lint/suspicious/useAwait: redirects must be async
+	async redirects() {
+		return [
+			{
+				source: "/side-quests/black-ops-6/reckoning/c-a-s-t-e-r-turret-upgrade",
+				destination: "/side-quests/black-ops-6/reckoning/caster-turret-upgrade",
+				permanent: true,
+			},
+			{
+				source: "/side-quests/black-ops-6/shattered-veil/s-a-m-trap-unlock",
+				destination: "/side-quests/black-ops-6/shattered-veil/sam-trap-unlock",
+				permanent: true,
+			},
+			{
+				source: "/bestiary/s-a-m",
+				destination: "/bestiary/sam",
+				permanent: true,
+			},
+			{
+				source: "/bestiary/kransy-soldat",
+				destination: "/bestiary/krasny-soldat",
+				permanent: true,
+			},
+			{
+				source: "/bestiary/the-corruputed-keeper",
+				destination: "/bestiary/the-corrupted-keeper",
+				permanent: true,
+			},
+			{
+				source: "/side-quests/black-ops-6/reckoning/free-1500-points",
+				destination: "/side-quests/black-ops-6/reckoning/paintings",
+				permanent: true,
+			},
+			{
+				source: "/black-ops-1",
+				destination: "/?game=black-ops-1",
+				permanent: true,
+			},
+			{
+				source: "/black-ops-2",
+				destination: "/?game=black-ops-2",
+				permanent: true,
+			},
+			{
+				source: "/black-ops-3",
+				destination: "/?game=black-ops-3",
+				permanent: true,
+			},
+			{
+				source: "/black-ops-4",
+				destination: "/?game=black-ops-4",
+				permanent: true,
+			},
+			{
+				source: "/black-ops-cold-war",
+				destination: "/?game=black-ops-cold-war",
+				permanent: true,
+			},
+			{
+				source: "/black-ops-6",
+				destination: "/?game=black-ops-6",
+				permanent: true,
+			},
+			{
+				source: "/side-quests/black-ops-6",
+				destination: "/side-quests?game=black-ops-6",
+				permanent: true,
+			},
+			{
+				source: "/side-quests/black-ops-6/liberty-falls",
+				destination: "/side-quests?map=liberty-falls",
+				permanent: true,
+			},
+			{
+				source: "/side-quests/black-ops-6/terminus",
+				destination: "/side-quests?map=terminus",
+				permanent: true,
+			},
+			{
+				source: "/side-quests/black-ops-6/citadelle-des-morts",
+				destination: "/side-quests?map=citadelle-des-morts",
+				permanent: true,
+			},
+			{
+				source: "/side-quests/black-ops-6/the-tomb",
+				destination: "/side-quests?map=the-tomb",
+				permanent: true,
+			},
+		]
+	},
+}
 
 const withMDX = createMDX({
-  extension: /\.(md|mdx)$/,
-});
+	extension: /\.(md|mdx)$/,
+})
 
-export default withBotId(withMDX(nextConfig));
+export default withBotId(withMDX(nextConfig))


### PR DESCRIPTION
removes the `minimumTTL` config for images to go back to the default instead of the 1 year minimum.