### PR TITLE
fix: brain rot missing game context

### DIFF
--- a/content/zombies/oscar.mdx
+++ b/content/zombies/oscar.mdx
@@ -7,5 +7,5 @@ past enemies like the moon <ZombieTooltip zombieKey="astronautZombie" /> or the 
 
 ---
 
-The **Drone Shield** he summons around him though can be easily destroyed with a weapon with the <AmmoModTooltip ammoModKey="brainRot" /> ammo mod, as the drones around him are
+The **Drone Shield** he summons around him though can be easily destroyed with a weapon with the <AmmoModTooltip ammoModKey="brainRot" game="blackOps7" /> ammo mod, as the drones around him are
 weak to that damage type. **O.S.C.A.R.** himself however, does not have any weaknesses to specific ammo mods.


### PR DESCRIPTION
Fixes missing game context for the brain rot ammo mod tooltip in the O.S.C.A.R. combat strategy.