### PR TITLE
perf: reduce maximum image quality to 75

### DIFF
--- a/app/(main)/[game]/[map]/page.tsx
+++ b/app/(main)/[game]/[map]/page.tsx
@@ -128,7 +128,6 @@ const MainQuestPage = Effect.fn("MainQuestPage")(
 										width={1280}
 										height={720}
 										sizes="(max-width: 1280px) 100vw, 1280px"
-										quality={100}
 									/>
 								</div>
 								<div className="relative mx-auto max-w-7xl">
@@ -137,7 +136,6 @@ const MainQuestPage = Effect.fn("MainQuestPage")(
 										width={1280}
 										height={720}
 										sizes="(max-width: 1280px) 100vw, 1280px"
-										quality={100}
 										priority
 										className="overflow-hidden xl:rounded-lg"
 									/>

--- a/app/(main)/bestiary/[id]/page.tsx
+++ b/app/(main)/bestiary/[id]/page.tsx
@@ -148,7 +148,6 @@ const ZombiePage = Effect.fn("ZombiePage")(function* ({ params }: PageProps<"/be
 							<div className="absolute inset-0 mx-auto hidden w-full opacity-35 blur-3xl dark:block">
 								<FeaturedImage
 									featuredImage={zombie.image}
-									quality={100}
 									width={422}
 									height={422}
 									sizes="422px"
@@ -159,7 +158,6 @@ const ZombiePage = Effect.fn("ZombiePage")(function* ({ params }: PageProps<"/be
 							<FeaturedImage
 								featuredImage={zombie.image}
 								alt={`${zombie.title} image`}
-								quality={100}
 								width={422}
 								height={422}
 								sizes="422px"

--- a/app/(main)/side-quests/[game]/[map]/[id]/page.tsx
+++ b/app/(main)/side-quests/[game]/[map]/[id]/page.tsx
@@ -123,7 +123,6 @@ const SideQuestPage = Effect.fn("SideQuestPage")(
 										sizes="(max-width: 1280px) 100vw, 1280px"
 										width={1280}
 										height={720}
-										quality={100}
 									/>
 								</div>
 								<div className="relative z-20 mx-auto max-w-7xl">
@@ -132,7 +131,6 @@ const SideQuestPage = Effect.fn("SideQuestPage")(
 										sizes="(max-width: 1280px) 100vw, 1280px"
 										width={1280}
 										height={720}
-										quality={100}
 										priority
 										className="overflow-hidden xl:rounded-lg"
 									/>

--- a/components/rich-text/rich-image/rich-image.tsx
+++ b/components/rich-text/rich-image/rich-image.tsx
@@ -30,7 +30,6 @@ export default function RichImage({ image, caption, alt }: RichImageProps) {
 			<div className="absolute top-4 right-0 left-0 z-10 mx-auto w-full opacity-35 blur-2xl">
 				<FeaturedImage
 					{...imageProps}
-					quality={100}
 					width={776}
 					height={436}
 					description={caption ?? undefined}
@@ -43,7 +42,6 @@ export default function RichImage({ image, caption, alt }: RichImageProps) {
 						{...imageProps}
 						width={776}
 						height={436}
-						quality={100}
 						description={caption ?? undefined}
 						alt={alt ?? ""}
 						className="cursor-default rounded-lg sm:cursor-zoom-in"
@@ -58,7 +56,6 @@ export default function RichImage({ image, caption, alt }: RichImageProps) {
 					<DialogClose>
 						<FeaturedImage
 							{...imageProps}
-							quality={100}
 							width={1920}
 							height={1080}
 							alt={alt ?? ""}

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,7 +24,7 @@ const nextConfig: NextConfig = {
 	images: {
 		formats: ["image/webp"],
 		deviceSizes: [640, 750, 828, 1080, 1200, 1920],
-		qualities: [75, 100],
+		qualities: [75],
 	},
 	// biome-ignore lint/suspicious/useAwait: redirects must be async
 	async redirects() {


### PR DESCRIPTION
Reduces the maximum allowed image optimization quality to 75 instead of 100 to save on bandwidth performance, as the visual quality difference is not noticeable most of the time to the human eye.