### PR TITLE
update(guides): clarify Astra Malorum quest steps

### DIFF
--- a/content/main-quests/astra-malorum.mdx
+++ b/content/main-quests/astra-malorum.mdx
@@ -271,6 +271,8 @@ the portal by destroying them before they reach it. Listen out for the distinct 
 
 <RichImage image="/content/astra-malorum/astra-malorum-defense-lockdown.webp" caption="Defense Lockdown" />
 
+> You do not need to destroy the drones for his **Drone Shield**, those will not go into the portal. He summons a separate set of drones that beep loudly and go straight for the portal.
+
 Once completed, you will be sucked into the portal and transported to the planet **Mars**.
 
 ## Step 6: Collect the Ascendant Eye
@@ -290,7 +292,8 @@ with it to collect the **Ascendant Eye**.
 <RichImage image="/content/astra-malorum/astra-malorum-final-pylon.webp" caption="Final Pylon" />
 <RichImage image="/content/astra-malorum/astra-malorum-ascendant-eye.webp" caption="Ascendant Eye" />
 
-> You can continuously shoot the final pylon to keep the **Ascendant Eye** in the arena. Otherwise, you'll need to flip round, wait for the mystical chime again, and shoot each of the pylons again.
+> You can continuously shoot the final pylon to keep the **Ascendant Eye** in the arena. Otherwise, you'll need to flip round, interact with the **Perfusion Machine** at the top of the temple,
+and shoot each of the pylons again.
 
 ## Step 7: Activate the Pylons
 Place the **Ascendant Eye** in the pedestal in the far-right corner of the arena, which will reveal five rods on top of the pillars around the arena. You must shoot each of the
@@ -332,7 +335,7 @@ and do a ground slam if you are in melee range.
 
 > Constant movement is key for this phase, using wall jumps and anti-gravity to avoid the rocks and maintaining distance to prevent her from ground slamming you. You can also turn your
 back to her during the ground slam if you have the <AugmentTooltip augmentKey="turtleShell" game="blackOps7" /> augment for <PerkTooltip perkKey="juggernog" game="blackOps7" /> to avoid
-taking health damage.
+taking health damage. <AugmentTooltip augmentKey="gunsUp" /> for <PerkTooltip perkKey="staminUp" game="blackOps7" /> is also helpful if you have it.
 
 ### Phase 3
 During this phase, <ZombieTooltip zombieKey="caltheris" /> becomes **Caltheris Ascendant** a bigger, stronger version of **Phase 2**. Her attacks are the same, but they're bigger and stronger so the plan remains


### PR DESCRIPTION
Clarifies the O.S.C.A.R. defense lockdown step for opening the portal to Mars, and the Ascendant Eye step for what you need to do if you fail to catch the eye during the first try.