### PR TITLE
fix(maps): mule kick missing from Astra Malorum

### DIFF
--- a/map-configs/astra-malorum.ts
+++ b/map-configs/astra-malorum.ts
@@ -312,6 +312,10 @@ export const config: MapConfig = {
 					locations: [{ x: 0.462, y: 0.265 }],
 				},
 				{
+					...perks["mule-kick"],
+					locations: [{ x: 0.652, y: 0.345 }],
+				},
+				{
 					...weapons.akita,
 					locations: [{ x: 0.714, y: 0.53 }],
 				},

--- a/map-configs/markers.ts
+++ b/map-configs/markers.ts
@@ -253,6 +253,14 @@ export const sharedMarkers: Record<SharedMarkerType, Marker> = {
 
 /** All perks appearing on any of the maps */
 export const perks = {
+	"mule-kick": {
+		id: "mule-kick",
+		title: "Mule Kick",
+		description: "Carry an extra weapon.",
+		icon: "/perks/mule-kick-cold-war.webp",
+		type: "perk",
+		category: "upgrades",
+	},
 	"wisp-tea": {
 		id: "wisp-tea",
 		title: "Wisp Tea",


### PR DESCRIPTION
Closes [CODZG-208](https://linear.app/codzombiesguides/issue/CODZG-208/feedback-form-submission)

Adds the missing Mule Kick perk machine location to the Astra Malorum interactive map.