### PR TITLE
fix: data serialization over network boundary

### DIFF
--- a/app/(interactive-map)/maps/[id]/page.tsx
+++ b/app/(interactive-map)/maps/[id]/page.tsx
@@ -99,11 +99,15 @@ const InteractiveMapPage = Effect.fn("InteractiveMapPage")(function* ({
 
 		return acc
 	}, initialGroups)
+	const transformedMaps = maps.map(map => ({
+		...map,
+		state: Option.getOrNull(map.state),
+	}))
 
 	return (
 		<SidebarProvider defaultOpen={defaultOpen}>
 			<Suspense fallback={<SidebarLoader />}>
-				<MapSidebar groups={groups} maps={maps} mapLayers={config.layers} />
+				<MapSidebar groups={groups} maps={transformedMaps} mapLayers={config.layers} />
 			</Suspense>
 			<div className="h-svh w-svw">
 				<CustomSideBarTrigger className={cn({ "top-18": config.layers.length === 1 })} />

--- a/app/(main)/(Home)/page.tsx
+++ b/app/(main)/(Home)/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { Option } from "effect"
 import { Suspense } from "react"
 import GridSection from "@/components/grid-section/grid-section"
 import HeroSection from "@/components/hero-section/hero-section"
@@ -16,9 +17,11 @@ export const metadata: Metadata = {
 
 export default function Home() {
 	const mainQuests = getMainQuests().map(quest => {
-		const { content, ...rest } = quest
+		const { content, state, difficulty, ...rest } = quest
 		return {
 			...rest,
+			state: Option.getOrNull(state),
+			difficulty: Option.getOrNull(difficulty),
 		}
 	})
 

--- a/app/(main)/bestiary/page.tsx
+++ b/app/(main)/bestiary/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { Option } from "effect"
 import { Suspense } from "react"
 import BestiaryFilters from "@/components/bestiary-filters/bestiary-filters"
 import BestiaryGridClient from "@/components/bestiary-grid/bestiary-grid"
@@ -33,8 +34,11 @@ export const metadata: Metadata = {
 
 export default function BestiaryPage() {
 	const zombies = getZombies().map(zombie => {
-		const { combatStrategy, ...rest } = zombie
-		return rest
+		const { combatStrategy, state, ...rest } = zombie
+		return {
+			...rest,
+			state: Option.getOrNull(state),
+		}
 	})
 	return (
 		<div className="flex w-full flex-col items-center justify-center">

--- a/app/(main)/side-quests/page.tsx
+++ b/app/(main)/side-quests/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { Option } from "effect"
 import { Suspense } from "react"
 import Breadcrumbs from "@/components/breadcrumbs/breadcrumbs"
 import GridSection from "@/components/grid-section/grid-section"
@@ -34,9 +35,10 @@ export const metadata: Metadata = {
 
 export default function SideQuests() {
 	const quests = getSideQuests().map(quest => {
-		const { content, ...rest } = quest
+		const { content, state, ...rest } = quest
 		return {
 			...rest,
+			state: Option.getOrNull(state),
 		}
 	})
 

--- a/components/bestiary-card/bestiary-card.tsx
+++ b/components/bestiary-card/bestiary-card.tsx
@@ -1,3 +1,4 @@
+import type { Route } from "next"
 import type { Zombie } from "@/data/zombies"
 import { Option } from "effect"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -17,25 +18,41 @@ export default function BestiaryCard({ zombie, zombieIndex }: IBestiaryCard) {
 	const isMobile = useIsMobile()
 	const priority = isMobile ? zombieIndex === 0 : zombieIndex <= 3
 	const alt = `${zombie.title} Image`
-	const state = Option.getOrNull(zombie.state)
+	const { href, tabIndex, stateBadge, applyClasses } = Option.match(zombie.state, {
+		onNone: () => ({
+			href: `/bestiary/${zombie.id}`,
+			tabIndex: 0,
+			stateBadge: null,
+			applyClasses: false,
+		}),
+		onSome: state => {
+			const isComingSoon = state === "Coming Soon"
+			return {
+				href: isComingSoon ? "#" : `/bestiary/${zombie.id}`,
+				tabIndex: isComingSoon ? -1 : 0,
+				stateBadge: isComingSoon ? <ComingSoonBadge /> : <NewBadge />,
+				applyClasses: isComingSoon,
+			}
+		},
+	})
 
 	return (
-		<article className={cn("h-full max-h-113", { "pointer-events-none": state === "Coming Soon" })}>
+		<article className={cn("h-full max-h-113", { "pointer-events-none": applyClasses })}>
 			<CustomLink
-				href={state === "Coming Soon" ? `#` : `/bestiary/${zombie.id}`}
+				href={href as Route}
 				aria-label={`View details for ${zombie.title}`}
-				aria-disabled={state === "Coming Soon"}
+				aria-disabled={applyClasses}
 				className="group outline-none"
-				tabIndex={state === "Coming Soon" ? -1 : 0}
+				tabIndex={tabIndex}
 			>
 				<Card
 					className={cn(
 						`relative h-full animate-fade-in cursor-pointer overflow-hidden shadow-xl transition-transform group-hover:scale-105 group-hover:outline-2 group-hover:outline-primary group-focus-visible:scale-105 group-focus-visible:outline-2 group-focus-visible:outline-primary dark:shadow-none`,
-						{ "opacity-75 dark:opacity-50": state === "Coming Soon" },
+						{ "opacity-75 dark:opacity-50": applyClasses },
 					)}
 				>
 					<div className="justify-end-safe absolute top-2 right-2 z-20 flex w-fit flex-wrap items-center gap-1">
-						{state === "Coming Soon" ? <ComingSoonBadge /> : state === "New" ? <NewBadge /> : null}
+						{stateBadge}
 						<TypeBadge type={zombie.type} />
 						{zombie.maps[0] ? (
 							<Badge className="badge-primary-gradient dark:dark-badge-primary-gradient">

--- a/components/bestiary-grid/bestiary-grid.tsx
+++ b/components/bestiary-grid/bestiary-grid.tsx
@@ -1,5 +1,7 @@
 "use client"
 import type { Zombie } from "@/data/zombies"
+import type { ContentState } from "@/types/data"
+import { Option } from "effect"
 import { Suspense, useEffect } from "react"
 import { useFilterParams } from "@/hooks/use-filter-params"
 import { MAP_LIMIT } from "@/utils/constants"
@@ -9,13 +11,18 @@ import EmptyGrid from "../empty/empty-grid"
 import GridPagination from "../grid-pagination/grid-pagination"
 import GridPaginationLoader from "../loaders/grid-pagination-loader"
 
+type TransformedZombie = Omit<Zombie, "combatStrategy" | "state"> & { state: ContentState | null }
+
 interface IBestiaryGridClient {
-	zombies: Omit<Zombie, "combatStrategy">[]
+	zombies: TransformedZombie[]
 }
 
 export default function BestiaryGridClient({ zombies }: IBestiaryGridClient) {
 	const { gameParams, mapParams, typeParams, page, validatePageParam } = useFilterParams()
-	let filteredZombies = zombies
+	let filteredZombies = zombies.map(zombie => ({
+		...zombie,
+		state: Option.fromNullable(zombie.state),
+	}))
 
 	if (gameParams.length > 0) {
 		filteredZombies = filteredZombies.filter(

--- a/components/interactive-map/map-sidebar.tsx
+++ b/components/interactive-map/map-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 import type { MapConfigMetadata, MapLayer } from "@/map-configs"
 import type { MapMarker, MarkerCategory } from "@/map-configs/markers"
+import type { ContentState } from "@/types/data"
 import { Option } from "effect"
 import { ChevronDown, MapPin } from "lucide-react"
 import Image from "next/image"
@@ -38,8 +39,10 @@ import {
 import { Switch } from "../ui/switch"
 import LayerSwitcher from "./layer-switcher"
 
+type TransformedMaps = Omit<MapConfigMetadata, "state"> & { state: ContentState | null }
+
 interface IMapSidebar {
-	maps: MapConfigMetadata[]
+	maps: TransformedMaps[]
 	groups: Record<MarkerCategory, Set<string>>
 	mapLayers: MapLayer[]
 }
@@ -80,12 +83,14 @@ export default function MapSidebar({ groups, maps, mapLayers }: IMapSidebar) {
 
 		const params = createParams()
 		if (params.size > 0) {
-
 			if (params.has("exclude")) {
 				const excludeParams = Option.match(Option.fromNullable(params.get("exclude")), {
 					onSome: value => {
 						const decoded = decodeURIComponent(value)
-						return decoded.split(",").map(v => v.trim()).filter(v => v.length > 0)
+						return decoded
+							.split(",")
+							.map(v => v.trim())
+							.filter(v => v.length > 0)
 					},
 					onNone: (): string[] => [],
 				})
@@ -118,9 +123,7 @@ export default function MapSidebar({ groups, maps, mapLayers }: IMapSidebar) {
 			return
 		}
 
-		const allMarkerIds = Array.from(
-			new Set(mapMarkers.map(marker => marker.type || marker.id)),
-		)
+		const allMarkerIds = Array.from(new Set(mapMarkers.map(marker => marker.type || marker.id)))
 
 		const params = createParams()
 		params.delete("include")
@@ -154,20 +157,18 @@ export default function MapSidebar({ groups, maps, mapLayers }: IMapSidebar) {
 										<SelectItem
 											key={map.id}
 											className={cn({
-												"pointer-events-none":
-													map.id === id || Option.getOrNull(map.state) === "Coming Soon",
+												"pointer-events-none": map.id === id || map.state === "Coming Soon",
 											})}
 											value={map.id}
 										>
 											<span
 												className={cn({
-													"text-muted-foreground":
-														map.id === id || Option.getOrNull(map.state) === "Coming Soon",
+													"text-muted-foreground": map.id === id || map.state === "Coming Soon",
 												})}
 											>
 												{map.title}
 											</span>
-											{Option.match(map.state, {
+											{Option.match(Option.fromNullable(map.state), {
 												onNone: () => null,
 												onSome: state =>
 													state === "Coming Soon" ? <ComingSoonBadge /> : <NewBadge />,

--- a/components/quest-grid/quest-grid.tsx
+++ b/components/quest-grid/quest-grid.tsx
@@ -1,6 +1,7 @@
 "use client"
-import type { MainQuest } from "@/data/main-quests"
+import type { MainQuest, MainQuestDifficulty } from "@/data/main-quests"
 import type { SideQuest } from "@/data/side-quests"
+import type { ContentState } from "@/types/data"
 import { Option, Predicate } from "effect"
 import { Suspense, useEffect } from "react"
 import GridPagination from "@/components/grid-pagination/grid-pagination"
@@ -11,13 +12,32 @@ import { MAP_LIMIT } from "@/utils/constants"
 import { calculateSkip } from "@/utils/functions.client"
 import EmptyGrid from "../empty/empty-grid"
 
+type TransformedMainQuest = Omit<MainQuest, "content" | "state" | "difficulty"> & {
+	difficulty: MainQuestDifficulty | null
+	state: ContentState | null
+}
+type TransformedSideQuest = Omit<SideQuest, "content" | "state"> & { state: ContentState | null }
+
 interface IQuestGridClient {
-	quests: (Omit<MainQuest, "content"> | Omit<SideQuest, "content">)[]
+	quests: TransformedMainQuest[] | TransformedSideQuest[]
 }
 
 export default function QuestGridClient({ quests }: IQuestGridClient) {
 	const { gameParams, mapParams, difficultyParams, page, validatePageParam } = useFilterParams()
-	let filteredQuests = quests
+	let filteredQuests = quests.map(quest => {
+		if (!Predicate.hasProperty(quest, "title")) {
+			return {
+				...quest,
+				difficulty: Option.fromNullable(quest.difficulty),
+				state: Option.fromNullable(quest.state),
+			}
+		}
+
+		return {
+			...quest,
+			state: Option.fromNullable(quest.state),
+		}
+	})
 
 	if (gameParams.length > 0) {
 		filteredQuests = filteredQuests.filter(quest => gameParams.includes(quest.map.game.id))

--- a/components/search-bar/search-bar.tsx
+++ b/components/search-bar/search-bar.tsx
@@ -14,6 +14,7 @@ export default async function SearchBar({ showFull }: ISearchBar) {
 	return await Effect.gen(function* () {
 		const availableMaps = yield* getInteractiveMaps().pipe(
 			Effect.map(maps => maps.filter(map => Option.getOrNull(map.state) !== "Coming Soon")),
+			Effect.map(maps => maps.map(map => ({ id: map.id, title: map.title }))),
 		)
 		const mainQuests = getMainQuests()
 		const games = getGames().map(g => ({

--- a/components/search-bar/search-input.tsx
+++ b/components/search-bar/search-input.tsx
@@ -45,7 +45,7 @@ interface SearchInputProps {
 	games: SearchEntry[]
 	quests: QuestSearch[]
 	zombies: SearchEntry[]
-	availableMaps: MapConfigMetadata[]
+	availableMaps: Pick<MapConfigMetadata, "id" | "title">[]
 }
 
 const filters = [

--- a/data/main-quests.ts
+++ b/data/main-quests.ts
@@ -1,3 +1,4 @@
+import type { ContentState } from "@/types/data"
 import { Effect, Option } from "effect"
 import { sortReleaseDateDesc } from "@/utils/functions.client"
 import { getMapByKey, type Maps } from "./maps"
@@ -10,7 +11,7 @@ export interface MainQuest {
 	/** The unique identifier of the main quest */
 	id: string
 	/** The state of the main quest */
-	state: Option.Option<"New" | "Coming Soon">
+	state: Option.Option<ContentState>
 	/** The difficulty of the main quest */
 	difficulty: Option.Option<MainQuestDifficulty>
 	/** The map of the main quest */

--- a/types/data.ts
+++ b/types/data.ts
@@ -1,0 +1,1 @@
+export type ContentState = "New" | "Coming Soon"


### PR DESCRIPTION
Transforms any `Option` modules into serializable data when crossing the network boundary from Server to Client, and then converts them back into `Option` modules once across the boundary within the application. This adds very minimal overhead, fixes the serialization/hydration errors in Next, and allows us to continue using the `Option` module from `Effect` in our application code.

I believe the minimal overhead here is worth using the module, as it is a very convenient module for pattern matching and type narrowing to determine the state of the UI to render.