### PR TITLE
fix(maps): all/none filter toggling

### DIFF
--- a/components/interactive-map/map-sidebar.tsx
+++ b/components/interactive-map/map-sidebar.tsx
@@ -185,12 +185,14 @@ export default function MapSidebar({ groups, maps, mapLayers }: IMapSidebar) {
 				<SidebarMenu className="mt-4 flex flex-row items-center justify-center">
 					<SidebarMenuButton
 						onClick={() => clearParam("exclude")}
+						aria-label="Show All Markers"
 						className="mx-2 cursor-pointer items-center justify-center bg-accent font-medium uppercase tracking-wide transition-colors hover:bg-primary dark:bg-accent/50 hover:dark:bg-primary"
 					>
 						All
 					</SidebarMenuButton>
 					<SidebarMenuButton
 						onClick={hideFilters}
+						aria-label="Hide All Markers"
 						className="mx-2 cursor-pointer items-center justify-center bg-accent font-medium uppercase tracking-wide transition-colors hover:bg-primary dark:bg-accent/50 hover:dark:bg-primary"
 					>
 						None


### PR DESCRIPTION
Closes [CODZG-212](https://linear.app/codzombiesguides/issue/CODZG-212/refactor-disable-filters-interactive-map-button)

Adds explict `ALL` and `NONE` buttons to show or hide all filters at any given moment to improve the UX around shared map URLs and just general map usage.