### PR TITLE
refactor: properly discriminate between quest types

### DIFF
--- a/components/quest-grid/quest-grid.tsx
+++ b/components/quest-grid/quest-grid.tsx
@@ -2,7 +2,7 @@
 import type { MainQuest, MainQuestDifficulty } from "@/data/main-quests"
 import type { SideQuest } from "@/data/side-quests"
 import type { ContentState } from "@/types/data"
-import { Option, Predicate } from "effect"
+import { Option } from "effect"
 import { Suspense, useEffect } from "react"
 import GridPagination from "@/components/grid-pagination/grid-pagination"
 import GridPaginationLoader from "@/components/loaders/grid-pagination-loader"
@@ -25,7 +25,7 @@ interface IQuestGridClient {
 export default function QuestGridClient({ quests }: IQuestGridClient) {
 	const { gameParams, mapParams, difficultyParams, page, validatePageParam } = useFilterParams()
 	let filteredQuests = quests.map(quest => {
-		if (!Predicate.hasProperty(quest, "title")) {
+		if (quest._tag === "MainQuest") {
 			return {
 				...quest,
 				difficulty: Option.fromNullable(quest.difficulty),
@@ -45,7 +45,7 @@ export default function QuestGridClient({ quests }: IQuestGridClient) {
 
 	if (difficultyParams.length > 0) {
 		filteredQuests = filteredQuests.filter(quest => {
-			if (!Predicate.hasProperty(quest, "title") && Option.isSome(quest.difficulty)) {
+			if (quest._tag === "MainQuest" && Option.isSome(quest.difficulty)) {
 				return difficultyParams.includes(quest.difficulty.value.toLowerCase())
 			}
 			return false
@@ -54,7 +54,7 @@ export default function QuestGridClient({ quests }: IQuestGridClient) {
 
 	if (mapParams.length > 0) {
 		filteredQuests = filteredQuests.filter(quest => {
-			if (Predicate.hasProperty(quest, "map")) {
+			if (quest._tag === "SideQuest") {
 				return mapParams.includes(quest.map.id)
 			}
 			return false

--- a/data/main-quests.ts
+++ b/data/main-quests.ts
@@ -8,6 +8,8 @@ import { getAdjacentItems } from "./utils"
 export type MainQuestDifficulty = "Easy" | "Medium" | "Hard"
 
 export interface MainQuest {
+	/** Internal tag to discriminate against for type-narrowing */
+	_tag: "MainQuest"
 	/** The unique identifier of the main quest */
 	id: string
 	/** The state of the main quest */
@@ -293,12 +295,13 @@ const mainQuestRegistry = {
 		map: getMapByKey("astraMalorum"),
 		content: Effect.promise(() => import("@/content/main-quests/astra-malorum.mdx")),
 	},
-} as const satisfies Record<string, MainQuest>
+} as const satisfies Record<string, Omit<MainQuest, "_tag">>
 
 const mainQuestMap = new Map<string, MainQuest>()
-const mainQuests: MainQuest[] = Object.values(mainQuestRegistry).sort((a, b) =>
-	sortReleaseDateDesc(a.map.releaseDate, b.map.releaseDate),
-)
+const mainQuests: MainQuest[] = Object.values(mainQuestRegistry)
+	.sort((a, b) => sortReleaseDateDesc(a.map.releaseDate, b.map.releaseDate))
+	.map(mainQuest => ({ ...mainQuest, _tag: "MainQuest" }))
+
 for (const mainQuest of mainQuests) {
 	mainQuestMap.set(mainQuest.map.id, mainQuest)
 }

--- a/data/side-quests.ts
+++ b/data/side-quests.ts
@@ -4,6 +4,8 @@ import { getMapByKey, type Maps } from "./maps"
 import { getAdjacentItems } from "./utils"
 
 export interface SideQuest {
+	/** Internal tag to discriminate against for type-narrowing */
+	_tag: "SideQuest"
 	/** The unique identifier for the side quest */
 	id: string
 	/** The title of the side quest */
@@ -26,7 +28,9 @@ export type SideQuestKey = keyof typeof sideQuestRegistry
  * @param key The key of the side quest
  * @returns The side quest with the given key
  */
-export const getSideQuestByKey = (key: SideQuestKey): SideQuest => sideQuestRegistry[key]
+export const getSideQuestByKey = (key: SideQuestKey): SideQuest => {
+	return { ...sideQuestRegistry[key], _tag: "SideQuest" }
+}
 
 /**
  * Get all SideQuests
@@ -1695,12 +1699,12 @@ const sideQuestRegistry = {
 			() => import("@/content/side-quests/hidden-power-ups-astra-malorum.mdx"),
 		),
 	},
-} as const satisfies Record<string, SideQuest>
+} as const satisfies Record<string, Omit<SideQuest, "_tag">>
 
 const sideQuestMap = new Map<string, SideQuest>()
-const sideQuests: SideQuest[] = Object.values(sideQuestRegistry).sort((a, b) =>
-	sortReleaseDateDesc(a.map.releaseDate, b.map.releaseDate),
-)
+const sideQuests: SideQuest[] = Object.values(sideQuestRegistry)
+	.sort((a, b) => sortReleaseDateDesc(a.map.releaseDate, b.map.releaseDate))
+	.map(sideQuest => ({ ...sideQuest, _tag: "SideQuest" }))
 
 for (const sideQuest of sideQuests) {
 	sideQuestMap.set(sideQuest.id, sideQuest)


### PR DESCRIPTION
Fixes https://github.com/PlagueFPS/cod-zombies/issues/127

Adds `_tag` property that allows for proper discriminated unions to more easily narrow down which quest type we are working with in app code.  
  
Closes [CODZG-210](https://linear.app/codzombiesguides/issue/CODZG-210/replace-property-based-type-discrimination-with-discriminated-unions)