### PR TITLE
feat: add game filtering to maps grid

### DIFF
--- a/app/maps/page.tsx
+++ b/app/maps/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next"
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import { Suspense } from "react"
 import Breadcrumbs from "@/components/breadcrumbs/breadcrumbs"
 import GridSection from "@/components/grid-section/grid-section"
-import PreviewCard from "@/components/interactive-map/preview-card"
-import PreviewCardLoader from "@/components/loaders/preview-card-loader"
+import InteractiveMapsFilters from "@/components/interactive-map/interactive-map-filters"
+import MapsGrid from "@/components/interactive-map/maps-grid"
+import FilterLoader from "@/components/loaders/filter-loader"
+import GridLoader from "@/components/loaders/grid-loader"
 import { getInteractiveMaps } from "@/data/interactive-map"
 import { BasePage } from "@/lib/layers"
 import { GLOBAL_OG_PROPS } from "@/utils/constants"
@@ -29,7 +31,11 @@ export const metadata: Metadata = {
 }
 
 const MapsPage = Effect.fn("MapsPage")(function* () {
-	const maps = yield* getInteractiveMaps()
+	const maps = yield* getInteractiveMaps().pipe(
+		Effect.map(maps => maps.map(m => ({ ...m, state: Option.getOrNull(m.state) }))),
+	)
+	const availableGames = new Set(maps.map(map => map.game))
+
 	return (
 		<div className="w-full flex-col items-center justify-center">
 			<div className="container flex flex-col items-center justify-center gap-6">
@@ -39,13 +45,12 @@ const MapsPage = Effect.fn("MapsPage")(function* () {
 						Browse our collection of interactive maps showcasing key spawn points, locations, and
 						more.
 					</p>
-					<div className="grid grid-cols-1 items-center gap-10 sm:grid-cols-2 lg:grid-cols-3">
-						{maps.map((map, index) => (
-							<Suspense key={map.id} fallback={<PreviewCardLoader />}>
-								<PreviewCard map={map} index={index} />
-							</Suspense>
-						))}
-					</div>
+					<Suspense fallback={<FilterLoader filters={["Game"]} />}>
+						<InteractiveMapsFilters availableGames={availableGames} />
+					</Suspense>
+					<Suspense fallback={<GridLoader />}>
+						<MapsGrid maps={maps} />
+					</Suspense>
 				</GridSection>
 			</div>
 		</div>

--- a/components/interactive-map/interactive-map-filters.tsx
+++ b/components/interactive-map/interactive-map-filters.tsx
@@ -1,0 +1,42 @@
+"use client"
+import { type GameKey, getGameByKey } from "@/data/games"
+import { useFilterParams } from "@/hooks/use-filter-params"
+import ClearFiltersButton from "../filters-combobox/clear-filters-button"
+import FiltersCombobox from "../filters-combobox/filters-combobox"
+import { ScrollArea, ScrollBar } from "../ui/scroll-area"
+
+interface InteractiveMapsFiltersProps {
+	availableGames: Set<GameKey>
+}
+
+export default function InteractiveMapsFilters({ availableGames }: InteractiveMapsFiltersProps) {
+	const { gameParams, toggleParam, clearAllFilters, clearParam } = useFilterParams()
+	const games = [...availableGames].map(gameKey => {
+		const { id, title } = getGameByKey(gameKey)
+		return {
+			id,
+			slug: id,
+			title,
+		}
+	})
+
+	const toggleGame = (game: string) => {
+		toggleParam("game", game, gameParams)
+	}
+
+	return (
+		<ScrollArea className="-mt-4">
+			<div className="flex w-full items-center gap-2 py-1 pl-0.5">
+				<FiltersCombobox
+					data={games}
+					currentSelection={gameParams}
+					title="Game"
+					toggleParam={toggleGame}
+					clearParam={() => clearParam("game")}
+				/>
+				{gameParams.length > 0 ? <ClearFiltersButton onClick={clearAllFilters} /> : null}
+			</div>
+			<ScrollBar orientation="horizontal" className="sr-only" />
+		</ScrollArea>
+	)
+}

--- a/components/interactive-map/maps-grid.tsx
+++ b/components/interactive-map/maps-grid.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import type { MapConfigMetadata } from "@/map-configs"
+import type { ContentState } from "@/types/data"
+import { Option } from "effect"
+import { getGameByKey } from "@/data/games"
+import { useFilterParams } from "@/hooks/use-filter-params"
+import PreviewCard from "./preview-card"
+
+type TransformedMetadata = Omit<MapConfigMetadata, "state"> & { state: ContentState | null }
+
+interface IMapsGrid {
+	maps: TransformedMetadata[]
+}
+
+export default function MapsGrid({ maps }: IMapsGrid) {
+	const { gameParams } = useFilterParams()
+	let filteredMaps = maps.map(map => ({
+		...map,
+		state: Option.fromNullable(map.state),
+	}))
+
+	if (gameParams.length > 0) {
+		filteredMaps = filteredMaps.filter(m => gameParams.includes(getGameByKey(m.game).id))
+	}
+
+	return (
+		<div className="grid grid-cols-1 items-center gap-10 sm:grid-cols-2 lg:grid-cols-3">
+			{filteredMaps.map((map, index) => (
+				<PreviewCard key={map.id} map={map} index={index} />
+			))}
+		</div>
+	)
+}


### PR DESCRIPTION
Adds game filtering logic to the interactive maps grid

Closes [CODZG-218](https://linear.app/codzombiesguides/issue/CODZG-218/add-game-filtering-logic-to-the-interactive-maps-route)