### PR TITLE
chore: add ads.txt to root

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2572200153117332, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Adds `ads.txt` file to public root directory to allow Google's crawler to view it.