### PR TITLE
fix: dynamic rendering of all pages

### DIFF
--- a/components/footer/copyright/copyright.tsx
+++ b/components/footer/copyright/copyright.tsx
@@ -1,5 +1,5 @@
-import type { DetailedHTMLProps, HTMLAttributes } from "react"
-import { connection } from "next/server"
+"use client"
+import { type DetailedHTMLProps, type HTMLAttributes, useEffect, useState } from "react"
 import { cn } from "@/lib/utils"
 
 interface CopyrightProps
@@ -7,8 +7,15 @@ interface CopyrightProps
 	className?: string
 }
 
-export default async function Copyright({ className }: CopyrightProps) {
-	await connection()
+const getDate = () => new Date().getFullYear()
+
+export default function Copyright({ className }: CopyrightProps) {
+	const [year, setYear] = useState(getDate())
+
+	useEffect(() => {
+		setYear(getDate())
+	}, [])
+
 	return (
 		<div
 			className={cn(
@@ -16,7 +23,7 @@ export default async function Copyright({ className }: CopyrightProps) {
 				className,
 			)}
 		>
-			<p>&copy; {new Date().getFullYear()} Call of Duty: Zombies Guides</p>
+			<p>&copy; {year} Call of Duty: Zombies Guides</p>
 			<p className="md:pr-12">
 				This website is an independent, unofficial Call of Duty: Zombies fan site. It is not
 				affiliated with or endorsed by Activision Blizzard. All trademarks, service marks, trade

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react"
 import ContactForm from "../contact-form/contact-form"
 import { CustomLink } from "../custom-link/custom-link"
 import Newsletter from "../newsletter/newsletter"
@@ -11,9 +10,7 @@ export default function Footer() {
 		<footer className="container relative m-auto flex flex-col items-center border-t px-4 py-8 text-sm">
 			<div className="grid grid-cols-1 items-center gap-8 md:grid-cols-3">
 				<div className="order-last flex flex-col-reverse items-center justify-center gap-4 text-center md:order-first md:items-start md:gap-6 md:text-left">
-					<Suspense>
-						<Copyright />
-					</Suspense>
+					<Copyright />
 					<Socials />
 				</div>
 				<Newsletter />

--- a/components/loaders/copyright-loader.tsx
+++ b/components/loaders/copyright-loader.tsx
@@ -1,9 +1,0 @@
-import { Skeleton } from "../ui/skeleton"
-
-export default function CopyrightLoader() {
-	return (
-		<div className="inline-flex items-center text-muted-foreground text-sm">
-			&copy; <Skeleton className="mr-1 ml-0.5 h-4 w-9" /> Call of Duty: Zombies Guides
-		</div>
-	)
-}


### PR DESCRIPTION
Converts the copyright component to a client component to resolve the current year on the client only instead of the server. Next.js will still prerendering the non-interactive HTML on the server resulting in a fast FCP so it does not affect performance in any meaningful way.