### PR TITLE
update: add bo7 variant for dead wire augments

### DIFF
--- a/data/augments.ts
+++ b/data/augments.ts
@@ -657,6 +657,11 @@ const augmentRegistry = {
 		description: "The stunned enemy can spread the stun to others.",
 		type: "Major",
 		image: "/augments/chain-lightning-major-augment.webp",
+		variants: {
+			blackOps7: {
+				image: "/augments/bo7/group-shroud-major-augment-bo7.webp",
+			}
+		}
 	},
 	bigGameDeadWire: {
 		id: "big-game-dead-wire",
@@ -664,6 +669,11 @@ const augmentRegistry = {
 		description: "Dead Wire can stun elite enemies.",
 		type: "Major",
 		image: "/augments/big-game-major-augment.webp",
+		variants: {
+			blackOps7: {
+				image: "/augments/bo7/big-game-major-augment-bo7.webp",
+			}
+		}
 	},
 	lightningStrike: {
 		id: "lightning-strike",
@@ -672,6 +682,11 @@ const augmentRegistry = {
 			"A bolt of lightning strikes from above, stunning all normal and special enemies in the area.",
 		type: "Major",
 		image: "/augments/electric-cherry-major-augment.webp",
+		variants: {
+			blackOps7: {
+				image: "/augments/bo7/reactive-armor-major-augment-bo7.webp",
+			}
+		}
 	},
 	highVoltage: {
 		id: "high-voltage",
@@ -679,6 +694,11 @@ const augmentRegistry = {
 		description: "Dead Wire deals slightly more damage.",
 		type: "Minor",
 		image: "/augments/retaliation-minor-augment.webp",
+		variants: {
+			blackOps7: {
+				image: "/augments/bo7/contact-burn-minor-augment-bo7.webp"
+			}
+		}
 	},
 	hasteDeadWire: {
 		id: "haste-dead-wire",
@@ -686,6 +706,11 @@ const augmentRegistry = {
 		description: "Dead Wire cooldown is slightly reduced.",
 		type: "Minor",
 		image: "/augments/chill-berry-minor-augment.webp",
+		variants: {
+			blackOps7: {
+				image: "/augments/bo7/haste-minor-augment-bo7.webp",
+			}
+		}
 	},
 	extensionDeadWire: {
 		id: "extension-dead-wire",
@@ -693,6 +718,11 @@ const augmentRegistry = {
 		description: "The stun and electric field last longer.",
 		type: "Minor",
 		image: "/augments/slow-death-minor-augment.webp",
+		variants: {
+			blackOps7: {
+				image: "/augments/bo7/extension-minor-augment-bo7.webp",
+			}
+		}
 	},
 	plague: {
 		id: "plague",


### PR DESCRIPTION
Adds the black ops 7 variant images for dead wires augments.