### PR TITLE
feat: add completion time filter to main quests grid

### DIFF
--- a/components/filters-combobox/filters-combobox.tsx
+++ b/components/filters-combobox/filters-combobox.tsx
@@ -32,7 +32,7 @@ export interface Filter {
 interface IFiltersCombobox {
 	data: Filter[]
 	currentSelection: string[]
-	title: "Game" | "Difficulty" | "Type" | "Map"
+	title: "Game" | "Difficulty" | "Type" | "Map" | "Completion Time"
 	enableInput?: boolean
 	inputPlaceholder?: string
 	toggleParam: (param: string) => void
@@ -67,6 +67,11 @@ const FiltersCombobox = ({
 				<DifficultyBadge difficulty={capitalize(selection) as MainQuestDifficulty} />
 			)),
 			Match.when("Type", () => <TypeBadge type={capitalize(selection) as ZombieType} />),
+			Match.when("Completion Time", () => (
+				<Badge className="badge-primary-gradient dark:dark-badge-primary-gradient">
+					{data.find(item => item.slug === selection)?.title || capitalize(selection)}
+				</Badge>
+			)),
 			Match.orElse(() => (
 				<Badge className="badge-primary-gradient dark:dark-badge-primary-gradient">
 					{capitalize(selection)}
@@ -140,7 +145,7 @@ const FiltersCombobox = ({
 								<CommandItem onSelect={clearParam} asChild>
 									<Button variant={"ghost"} size={"sm"} className="items-center justify-center">
 										<Trash className="size-4 text-red-800 dark:text-red-400" />
-										<span>Clear {title} Filters</span>
+										<span className="text-xs">Clear {title} Filters</span>
 									</Button>
 								</CommandItem>
 							</div>

--- a/components/quest-filters/main-quest-filters.tsx
+++ b/components/quest-filters/main-quest-filters.tsx
@@ -2,7 +2,11 @@ import { Option } from "effect"
 import { Suspense } from "react"
 import FilterLoader from "@/components/loaders/filter-loader"
 import { getGames } from "@/data/games"
-import { getMainQuests, type MainQuestDifficulty } from "@/data/main-quests"
+import {
+	getMainQuests,
+	MAIN_QUEST_TIME_RANGE_FILTERS,
+	type MainQuestDifficulty,
+} from "@/data/main-quests"
 import { slugify, sortDifficulties } from "@/utils/functions.client"
 import QuestFiltersClient from "./quest-filters.client"
 
@@ -32,10 +36,20 @@ export default function MainQuestFilters() {
 			slug: slugify(difficulty),
 			title: difficulty,
 		}))
+	const timeFilters = MAIN_QUEST_TIME_RANGE_FILTERS.map(range => ({
+		id: range.id,
+		slug: range.slug,
+		title: range.title,
+	}))
 
 	return (
-		<Suspense fallback={<FilterLoader filters={["Game", "Difficulty"]} />}>
-			<QuestFiltersClient type="main" games={gameFilters} difficulties={difficultyFilters} />
+		<Suspense fallback={<FilterLoader filters={["Game", "Difficulty", "Completion Time"]} />}>
+			<QuestFiltersClient
+				type="main"
+				games={gameFilters}
+				difficulties={difficultyFilters}
+				timeRanges={timeFilters}
+			/>
 		</Suspense>
 	)
 }

--- a/components/quest-filters/quest-filters.client.tsx
+++ b/components/quest-filters/quest-filters.client.tsx
@@ -12,6 +12,7 @@ interface MainQuestFilters {
 	type: "main"
 	games: Filter[]
 	difficulties: Filter[]
+	timeRanges: Filter[]
 }
 
 interface SideQuestFilters {
@@ -28,6 +29,7 @@ export default function QuestFiltersClient(props: TQuestFiltersClient) {
 		mapParams,
 		difficultyParams,
 		gameParams,
+		timeParams,
 		sortParam,
 		toggleParam,
 		clearParam,
@@ -46,7 +48,11 @@ export default function QuestFiltersClient(props: TQuestFiltersClient) {
 	const toggleDifficulty = (difficulty: string) => {
 		toggleParam("difficulty", difficulty, difficultyParams)
 	}
-	
+
+	const toggleTime = (time: string) => {
+		toggleParam("time", time, timeParams)
+	}
+
 	const sortOptions = type === "main" ? getMainQuestSortOptions() : getSideQuestSortOptions()
 	const defaultSort = sortOptions.at(0)?.value ?? "latest"
 	const validSortValue = sortParam && sortOptions.some(option => option.value === sortParam) ? sortParam : defaultSort	
@@ -69,6 +75,13 @@ export default function QuestFiltersClient(props: TQuestFiltersClient) {
 							title="Difficulty"
 							toggleParam={toggleDifficulty}
 							clearParam={() => clearParam("difficulty")}
+						/>
+						<FiltersCombobox
+							data={props.timeRanges}
+							currentSelection={timeParams}
+							title="Completion Time"
+							toggleParam={toggleTime}
+							clearParam={() => clearParam("time")}
 						/>
 					</>
 				) : (
@@ -97,7 +110,10 @@ export default function QuestFiltersClient(props: TQuestFiltersClient) {
 					onValueChange={updateSort}
 					triggerClass="ml-auto"
 				/>
-				{gameParams.length > 0 || mapParams.length > 0 || difficultyParams.length > 0 ? (
+				{gameParams.length > 0 ||
+				mapParams.length > 0 ||
+				difficultyParams.length > 0 ||
+				timeParams.length > 0 ? (
 					<ClearFiltersButton onClick={clearAllFilters} />
 				) : null}
 			</div>

--- a/components/quest-grid/quest-grid.tsx
+++ b/components/quest-grid/quest-grid.tsx
@@ -1,5 +1,4 @@
 "use client"
-import type { MainQuest, MainQuestDifficulty } from "@/data/main-quests"
 import type { SideQuest } from "@/data/side-quests"
 import type { ContentState } from "@/types/data"
 import { Option } from "effect"
@@ -7,10 +6,16 @@ import { Suspense, useEffect } from "react"
 import GridPagination from "@/components/grid-pagination/grid-pagination"
 import GridPaginationLoader from "@/components/loaders/grid-pagination-loader"
 import QuestPreviewCard from "@/components/quest-preview-card/quest-preview-card"
+import {
+	MAIN_QUEST_TIME_RANGE_FILTERS,
+	type MainQuest,
+	type MainQuestDifficulty,
+} from "@/data/main-quests"
 import { useFilterParams } from "@/hooks/use-filter-params"
 import { MAP_LIMIT } from "@/utils/constants"
 import {
 	calculateSkip,
+	getEstimatedTimeMidpoint,
 	sortDifficulties,
 	sortEstimatedTimeAsc,
 	sortEstimatedTimeDesc,
@@ -30,8 +35,15 @@ interface IQuestGridClient {
 }
 
 export default function QuestGridClient({ quests }: IQuestGridClient) {
-	const { gameParams, mapParams, difficultyParams, sortParam, page, validatePageParam } =
-		useFilterParams()
+	const {
+		gameParams,
+		mapParams,
+		difficultyParams,
+		timeParams,
+		sortParam,
+		page,
+		validatePageParam,
+	} = useFilterParams()
 	let filteredQuests = quests.map(quest => {
 		if (quest._tag === "MainQuest") {
 			return {
@@ -66,6 +78,22 @@ export default function QuestGridClient({ quests }: IQuestGridClient) {
 				return mapParams.includes(quest.map.id)
 			}
 			return false
+		})
+	}
+
+	if (timeParams.length > 0) {
+		filteredQuests = filteredQuests.filter(quest => {
+			if (quest._tag !== "MainQuest") return false
+			const midpoint = getEstimatedTimeMidpoint(quest.estimatedTimeMins)
+			return timeParams.some(slug => {
+				const range = MAIN_QUEST_TIME_RANGE_FILTERS.find(r => r.slug === slug)
+				if (!range) return false
+				// Last range "120-plus" is inclusive on both ends; others: minMins <= midpoint < maxMins
+				if (range.slug === "120-plus") {
+					return midpoint >= range.minMins && midpoint <= range.maxMins
+				}
+				return midpoint >= range.minMins && midpoint < range.maxMins
+			})
 		})
 	}
 

--- a/data/main-quests.ts
+++ b/data/main-quests.ts
@@ -72,6 +72,22 @@ export const getMainQuestSortOptions = (): SortOption[] => [
 	{ value: "time-desc", label: "Completion Time: Longest to Shortest" }
 ]
 
+export interface MainQuestTimeRangeFilter {
+	id: string
+	slug: string
+	title: string
+	minMins: number
+	maxMins: number
+}
+
+/** Time range options for filtering main quests by completion time (midpoint). */
+export const MAIN_QUEST_TIME_RANGE_FILTERS: MainQuestTimeRangeFilter[] = [
+	{ id: "under-30", slug: "under-30", title: "Under 30 min", minMins: 0, maxMins: 30 },
+	{ id: "30-60", slug: "30-60", title: "30 min–1 hr", minMins: 30, maxMins: 60 },
+	{ id: "60-120", slug: "60-120", title: "1–2 hrs", minMins: 60, maxMins: 120 },
+	{ id: "120-plus", slug: "120-plus", title: "2+ hrs", minMins: 120, maxMins: Infinity },
+]
+
 const mainQuestRegistry = {
 	casimirMechanism: {
 		id: "casimir-mechanism",

--- a/hooks/use-filter-params.ts
+++ b/hooks/use-filter-params.ts
@@ -11,6 +11,8 @@ interface FilterParamsResult {
 	difficultyParams: string[]
 	/** Array of selected type parameter values */
 	typeParams: string[]
+	/** Array of selected completion time range parameter values */
+	timeParams: string[]
 	/** Current sort parameter value */
 	sortParam: string | null
 	/** Current page number */
@@ -69,7 +71,7 @@ interface FilterParamsResult {
 	updateURLParams: (params: URLSearchParams) => void
 }
 
-type Param = "type" | "map" | "game" | "difficulty"
+type Param = "type" | "map" | "game" | "difficulty" | "time"
 
 /**
  * Custom hook for managing site search parameters in the URL.
@@ -86,6 +88,7 @@ export function useFilterParams(): FilterParamsResult {
 	const mapParams = searchParams.getAll("map")
 	const difficultyParams = searchParams.getAll("difficulty")
 	const typeParams = searchParams.getAll("type")
+	const timeParams = searchParams.getAll("time")
 	const sortParam = searchParams.get("sort")
 	const pageParam = searchParams.get("page")
 	const page = pageParam ? parseInt(pageParam, 10) : 1
@@ -132,6 +135,7 @@ export function useFilterParams(): FilterParamsResult {
 		params.delete("map")
 		params.delete("difficulty")
 		params.delete("type")
+		params.delete("time")
 		params.delete("sort")
 		updateURLParams(params)
 	}
@@ -164,6 +168,7 @@ export function useFilterParams(): FilterParamsResult {
 		mapParams,
 		difficultyParams,
 		typeParams,
+		timeParams,
 		sortParam,
 		page,
 		searchParams,


### PR DESCRIPTION
Closes [CODZG-238](https://linear.app/codzombiesguides/issue/CODZG-238/new-filter-by-time-to-complete)

Adds a new filter to the main quest grid for `Completion Time` to allow users to quickly find quests that fit into the time range they have available to play or want to spend.