### PR TITLE
update(ui): adjust time display and remove shadow and background for ToC

### DIFF
--- a/components/table-of-contents/table-of-contents.tsx
+++ b/components/table-of-contents/table-of-contents.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronUp } from "lucide-react"
 import Link from "next/link"
 import { useState } from "react"
 import { useShortcut } from "@/hooks/use-keyboard-shortcuts"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { useTableOfContents } from "@/hooks/use-table-of-contents"
 import { cn } from "@/lib/utils"
 import { IS_MAC_OS } from "@/utils/constants"
@@ -13,7 +14,6 @@ import { Progress } from "../ui/progress"
 import { ScrollArea, ScrollBar } from "../ui/scroll-area"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
 import MobileTableOfContents from "./mobile-table-of-contents"
-import { useIsMobile } from "@/hooks/use-mobile"
 
 export interface Heading {
 	type: "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
@@ -34,8 +34,8 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
 
 	return (
 		<>
-			{ !isMobile ? (
-				<aside className="sticky top-20 z-40 ml-4 hidden h-fit w-85 shrink-0 bg-background px-6 shadow-md xl:block dark:shadow-none">
+			{!isMobile ? (
+				<aside className="sticky top-20 z-40 ml-4 hidden h-fit w-85 shrink-0 bg-transparent px-6 xl:block">
 					<div className="relative flex flex-col">
 						<div className="mt-4 flex flex-col items-center justify-center">
 							<div className="mb-2 flex w-full items-center justify-between">
@@ -127,7 +127,7 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
 						</div>
 					</div>
 				</aside>
-			): (
+			) : (
 				<MobileTableOfContents
 					headings={headings}
 					activeHeading={activeHeading}

--- a/utils/functions.client.ts
+++ b/utils/functions.client.ts
@@ -132,11 +132,11 @@ const formatMinutesForDisplay = (m: number) => {
 	if (mins < 60) return `${mins}m`
 	const hours = Math.floor(mins / 60)
 	const remainder = mins % 60
-	return remainder === 0 ? `${hours}h` : `${hours}h${remainder}m`
+	return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`
 }
 
 /**
- * Formats a time range (min/max in minutes) for display, e.g. "45m", "1h30m", "45m-1h30m".
+ * Formats a time range (min/max in minutes) for display, e.g. "45m", "1h 30m", "45m-1h 30m".
  * @param range - The time range with min and max in minutes.
  * @returns A formatted string for the time range.
  */
@@ -146,7 +146,7 @@ export const formatEstimatedTimeRange = (range: { min: number; max: number }) =>
 		: `${formatMinutesForDisplay(range.min)}-${formatMinutesForDisplay(range.max)}`
 
 /**
- * Formats the midpoint of a time range for display, e.g. "45m", "1h", "1h20m".
+ * Formats the midpoint of a time range for display, e.g. "45m", "1h", "1h 20m".
  * @param range - The time range with min and max in minutes.
  * @returns A formatted string for the midpoint.
  */


### PR DESCRIPTION
Adjust the way completion time is displayed from `1h30m` to `1h 30m` for readability, and remove the background and box shadow for the Table of Contents to prevent it from looking out of place when shown on top of some aesthetic elements.