### PR TITLE
update(emails): use segments instead of audiences in API calls

### DIFF
--- a/lib/services/emails.ts
+++ b/lib/services/emails.ts
@@ -23,9 +23,7 @@ export class Email extends Effect.Service<Email>()("Email", {
 	effect: Effect.gen(function* () {
 		const getContact = (email: string) =>
 			Effect.gen(function* () {
-				const { data, error } = yield* Effect.promise(() =>
-					resend.contacts.get({ audienceId: Redacted.value(env.RESEND_AUDIENCE_ID), email }),
-				)
+				const { data, error } = yield* Effect.promise(() => resend.contacts.get({ email }))
 
 				if (error && error.name !== "not_found")
 					return yield* new GetContactError({ message: error.message, cause: error })
@@ -36,7 +34,10 @@ export class Email extends Effect.Service<Email>()("Email", {
 		const createContact = (email: string) =>
 			Effect.gen(function* () {
 				const { data, error } = yield* Effect.promise(() =>
-					resend.contacts.create({ audienceId: Redacted.value(env.RESEND_AUDIENCE_ID), email }),
+					resend.contacts.create({
+						segments: [{ id: Redacted.value(env.RESEND_AUDIENCE_ID) }],
+						email,
+					}),
 				)
 
 				if (error) return yield* new CreateContactError({ message: error.message, cause: error })
@@ -46,9 +47,7 @@ export class Email extends Effect.Service<Email>()("Email", {
 
 		const removeContact = (email: string) =>
 			Effect.gen(function* () {
-				const { data, error } = yield* Effect.promise(() =>
-					resend.contacts.remove({ audienceId: Redacted.value(env.RESEND_AUDIENCE_ID), email }),
-				)
+				const { data, error } = yield* Effect.promise(() => resend.contacts.remove({ email }))
 
 				if (error) return yield* new RemoveContactError({ message: error.message, cause: error })
 


### PR DESCRIPTION
Uses Resends new `segments` API instead of the `audiences` for creating and removing contacts. This also fixes the issue of newly created contacts not being removed from the audience if unsubscribed due to not being assigned a segment.