### PR TITLE
Unit tests for custom scripts and Node platform alignment

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "cod-zombies",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
-        "@effect/platform-bun": "^4.0.0-beta.35",
+        "@effect/platform-node": "^4.0.0-beta.35",
         "@linear/sdk": "^78.0.0",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
@@ -111,9 +111,9 @@
 
     "@effect/language-service": ["@effect/language-service@0.80.0", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-dKMATT1fDzaCpNrICpXga7sjJBtFLpKCAoE/1MiGXI8UwcHA9rmAZ2t52JO9g/kJpERWyomkJ+rl+VFlwNIofg=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.35", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.35" }, "peerDependencies": { "effect": "^4.0.0-beta.35" } }, "sha512-vJRFukk3CjPeJzJF2qwJH2Cd7DcN9RUsvwRODU1pQJOI7K+iXX1jgziuN70r6qrNl65g6zLF1A1nApK3i4u8Ig=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.40", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.40", "mime": "^4.1.0", "undici": "^7.24.0" }, "peerDependencies": { "effect": "^4.0.0-beta.40", "ioredis": "^5.7.0" } }, "sha512-IRBlYErAdImh0Pv92PppgFK2wnNAv48Bib6FHjp+89tjzfZ0LHv5TQvEeCXo8ZgHJDyxiPJ5/ugV+jnzpZCG5Q=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.35", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.35" } }, "sha512-9bPqNV988itKJ7MQoJuzmR014DB9EZRDOnhJt/+iJlb8qLoR9HnCzNJb9gfBdYhFmVYc8DMsQxG81rdJzpv9tg=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.40", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.40" } }, "sha512-WMRVG7T8ZDALKCOacsx2ZZj3Ccaoq8YGeD9q7ZL4q8RwQv8Nmrl+4+KZl95/zHCqXzgK9oUJOlBfQ7CZr6PQOQ=="],
 
     "@effect/vitest": ["@effect/vitest@4.0.0-beta.35", "", { "peerDependencies": { "effect": "^4.0.0-beta.35", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-wdt6j7yNL8cYXSyi1QWch4UPpjB0C7QBzStmdMSmIzAZ3ZVAUcyQkdfg/hnUJt6NPZMdjVmbI7m93ml5Mqqnhw=="],
 
@@ -230,6 +230,8 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -727,6 +729,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
@@ -756,6 +760,8 @@
     "decode-named-character-reference": ["decode-named-character-reference@1.2.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -891,6 +897,8 @@
 
     "inline-style-parser": ["inline-style-parser@0.2.4", "", {}, "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="],
 
+    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -964,6 +972,10 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "loader-runner": ["loader-runner@4.3.0", "", {}, "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
     "log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
 
@@ -1054,6 +1066,8 @@
     "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -1183,6 +1197,10 @@
 
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
 
     "remark-mdx": ["remark-mdx@3.1.1", "", { "dependencies": { "mdast-util-mdx": "^3.0.0", "micromark-extension-mdxjs": "^3.0.0" } }, "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg=="],
@@ -1244,6 +1262,8 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
@@ -1322,6 +1342,8 @@
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "undici": ["undici@7.24.5", "", {}, "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/lib/layers.ts
+++ b/lib/layers.ts
@@ -1,6 +1,6 @@
-import { BunServices } from "@effect/platform-bun"
+import { NodeServices } from "@effect/platform-node"
 import { ManagedRuntime } from "effect"
 import { Email } from "@/lib/services/emails"
 
-export const PageRuntime = ManagedRuntime.make(BunServices.layer)
+export const PageRuntime = ManagedRuntime.make(NodeServices.layer)
 export const APIRuntime = ManagedRuntime.make(Email.layer)

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
 		"generate:og:images": "bun scripts/generate-og-images.tsx"
 	},
 	"dependencies": {
+		"@effect/platform-node": "^4.0.0-beta.35",
 		"@base-ui/react": "^1.3.0",
-		"@effect/platform-bun": "^4.0.0-beta.35",
 		"@linear/sdk": "^78.0.0",
 		"@mdx-js/loader": "^3.1.1",
 		"@mdx-js/react": "^3.1.1",

--- a/scripts/generate-content-paths.ts
+++ b/scripts/generate-content-paths.ts
@@ -1,5 +1,5 @@
 import type { PlatformError } from "effect/PlatformError"
-import { BunRuntime, BunServices } from "@effect/platform-bun"
+import { NodeRuntime, NodeServices } from "@effect/platform-node"
 import { Clock, Effect, FileSystem, HashSet, Path, Predicate } from "effect"
 import { toPascalCase } from "@/utils/shared-functions"
 
@@ -95,7 +95,7 @@ function headerComment(contentDir: string, duration: string | number) {
  */\n\n`
 }
 
-const generateContentPaths = Effect.fn("generateContentPaths")(function* () {
+export const generateContentPaths = Effect.fn("generateContentPaths")(function* () {
 	const fs = yield* FileSystem.FileSystem
 	const path = yield* Path.Path
 	const cwd = process.cwd()
@@ -164,4 +164,10 @@ const generateContentPaths = Effect.fn("generateContentPaths")(function* () {
 	)
 })
 
-generateContentPaths().pipe(Effect.provide(BunServices.layer), BunRuntime.runMain)
+export const runGenerateContentPathsProgram = generateContentPaths().pipe(
+	Effect.provide(NodeServices.layer),
+)
+
+if (import.meta.main) {
+	NodeRuntime.runMain(runGenerateContentPathsProgram)
+}

--- a/scripts/generate-image-paths.ts
+++ b/scripts/generate-image-paths.ts
@@ -1,5 +1,5 @@
 import type { PlatformError } from "effect/PlatformError"
-import { BunRuntime, BunServices } from "@effect/platform-bun"
+import { NodeRuntime, NodeServices } from "@effect/platform-node"
 import { Clock, Effect, FileSystem, HashSet, Path, Predicate, SynchronizedRef } from "effect"
 import { SUPPORTED_IMAGE_FORMATS } from "@/scripts/utils"
 import { toPascalCase } from "@/utils/shared-functions"
@@ -120,7 +120,7 @@ function headerComment(publicDir: string, duration: string | number) {
  */\n\n`
 }
 
-const generateImagePaths = Effect.fn("generateImagePaths")(function* () {
+export const generateImagePaths = Effect.fn("generateImagePaths")(function* () {
 	const fs = yield* FileSystem.FileSystem
 	const path = yield* Path.Path
 	const cwd = process.cwd()
@@ -199,4 +199,10 @@ const generateImagePaths = Effect.fn("generateImagePaths")(function* () {
 	yield* Effect.log(`- / (root): ${rootWebPaths.length} image(s) -> type RootImagePath`)
 })
 
-generateImagePaths().pipe(Effect.provide(BunServices.layer), BunRuntime.runMain)
+export const runGenerateImagePathsProgram = generateImagePaths().pipe(
+	Effect.provide(NodeServices.layer),
+)
+
+if (import.meta.main) {
+	NodeRuntime.runMain(runGenerateImagePathsProgram)
+}

--- a/scripts/generate-last-modified.ts
+++ b/scripts/generate-last-modified.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process"
-import { BunRuntime, BunServices } from "@effect/platform-bun"
+import { NodeRuntime, NodeServices } from "@effect/platform-node"
 import {
 	DateTime,
 	Effect,
@@ -63,7 +63,7 @@ const storeFileMetadata = Effect.fn("storeFileMetadata")(function* (
 	}
 })
 
-const parseGitBatchOutput = Effect.fn("parseGitBatchOutput")(function* (
+export const parseGitBatchOutput = Effect.fn("parseGitBatchOutput")(function* (
 	output: string,
 	allFiles: MutableHashSet.MutableHashSet<string>,
 	repoRoot: string,
@@ -113,7 +113,7 @@ const parseGitBatchOutput = Effect.fn("parseGitBatchOutput")(function* (
 	return result
 })
 
-const getAllContentFiles = Effect.fn("getAllContentFiles")(function* (dir: string) {
+export const getAllContentFiles = Effect.fn("getAllContentFiles")(function* (dir: string) {
 	const path = yield* Path.Path
 	const fs = yield* FileSystem.FileSystem
 	const files = MutableHashSet.empty<string>()
@@ -160,7 +160,7 @@ const getAllContentFiles = Effect.fn("getAllContentFiles")(function* (dir: strin
 	return files
 })
 
-const generateLastModified = Effect.gen(function* () {
+export const generateLastModified = Effect.gen(function* () {
 	const path = yield* Path.Path
 	const fs = yield* FileSystem.FileSystem
 	const contentDir = path.join(process.cwd(), "content")
@@ -195,6 +195,10 @@ const generateLastModified = Effect.gen(function* () {
 	const encodedData = yield* encodeLastModifiedData(lastModifiedData)
 	yield* fs.writeFileString(outputPath, encodedData)
 	yield* Effect.log(`Data written to: ${outputPath}`)
-}).pipe(Effect.withLogSpan("generate_last_modified"), Effect.provide(BunServices.layer))
+}).pipe(Effect.withLogSpan("generate_last_modified"), Effect.provide(NodeServices.layer))
 
-BunRuntime.runMain(generateLastModified)
+export const runGenerateLastModifiedProgram = generateLastModified
+
+if (import.meta.main) {
+	NodeRuntime.runMain(runGenerateLastModifiedProgram)
+}

--- a/scripts/generate-og-images.tsx
+++ b/scripts/generate-og-images.tsx
@@ -1,5 +1,5 @@
 import type { MapsImagePath, ZombiesImagePath } from "@/types/generated/image-paths.gen"
-import { BunRuntime, BunServices } from "@effect/platform-bun"
+import { NodeRuntime, NodeServices } from "@effect/platform-node"
 import { Array as Arr, Effect, FileSystem, Match, Option, Path, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
 import { ImageResponse } from "next/og"
@@ -649,7 +649,7 @@ const outputDirFlag = Flag.directory("output-dir").pipe(
 	),
 )
 
-const generateOgCommand = Command.make(
+export const generateOgCommand = Command.make(
 	"generate-og-images",
 	{
 		mapFlag: mapSlugFlag,
@@ -806,10 +806,10 @@ const generateOgCommand = Command.make(
 		}),
 )
 
-Command.run(generateOgCommand, {
+export const runGenerateOgImagesProgram = Command.run(generateOgCommand, {
 	version: "1.0.0",
-}).pipe(
-	Effect.withLogSpan("generate_og_images"),
-	Effect.provide(BunServices.layer),
-	BunRuntime.runMain,
-)
+}).pipe(Effect.withLogSpan("generate_og_images"), Effect.provide(NodeServices.layer))
+
+if (import.meta.main) {
+	NodeRuntime.runMain(runGenerateOgImagesProgram)
+}

--- a/scripts/image-optimization.ts
+++ b/scripts/image-optimization.ts
@@ -1,4 +1,4 @@
-import { BunRuntime, BunServices } from "@effect/platform-bun"
+import { NodeRuntime, NodeServices } from "@effect/platform-node"
 import { Clock, Duration, Effect, FileSystem, HashSet, Path, Schema, Ref } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
 import sharp from "sharp"
@@ -116,7 +116,7 @@ const transformResizeAndOptimize = Effect.fn("transformResizeAndOptimize")(funct
 
 type TransformResult = Effect.Success<ReturnType<typeof transformMap>>
 
-const optimizeCommand = Command.make(
+export const optimizeCommand = Command.make(
 	"optimize",
 	{
 		dir: dirOption,
@@ -213,6 +213,10 @@ const optimizeCommand = Command.make(
 		}).pipe(Effect.withLogSpan("optimize_assets")),
 )
 
-Command.run(optimizeCommand, {
+export const runImageOptimizationProgram = Command.run(optimizeCommand, {
 	version: "1.0.0",
-}).pipe(Effect.provide(BunServices.layer), BunRuntime.runMain)
+}).pipe(Effect.provide(NodeServices.layer))
+
+if (import.meta.main) {
+	NodeRuntime.runMain(runImageOptimizationProgram)
+}

--- a/tests/scripts/generate-content-paths.test.ts
+++ b/tests/scripts/generate-content-paths.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { NodeServices } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { TestClock } from "effect/testing"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { generateContentPaths } from "@/scripts/generate-content-paths"
+
+const testLayers = Layer.mergeAll(TestClock.layer(), NodeServices.layer)
+
+describe("scripts/generate-content-paths", () => {
+	let prevCwd: string
+	let tmpRoot: string
+
+	beforeEach(() => {
+		vi.useFakeTimers({ now: new Date("2024-06-15T12:00:00.000Z") })
+		prevCwd = process.cwd()
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gen-content-paths-"))
+		process.chdir(tmpRoot)
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		process.chdir(prevCwd)
+		fs.rmSync(tmpRoot, { recursive: true, force: true })
+	})
+
+	it("fails when the content directory is missing", async () => {
+		await expect(
+			Effect.runPromise(
+				generateContentPaths().pipe(
+					Effect.provide(testLayers),
+					Effect.flip,
+				),
+			),
+		).resolves.toMatch(/Content directory does not exist/)
+	})
+
+	it("writes sorted union types for each content subfolder and stable ContentPaths union order", async () => {
+		fs.mkdirSync(path.join(tmpRoot, "types", "generated"), { recursive: true })
+		fs.mkdirSync(path.join(tmpRoot, "content", "beta"), { recursive: true })
+		fs.mkdirSync(path.join(tmpRoot, "content", "alpha", "nested"), { recursive: true })
+		fs.writeFileSync(path.join(tmpRoot, "content", "beta", "second.mdx"), "# B")
+		fs.writeFileSync(path.join(tmpRoot, "content", "alpha", "first.mdx"), "# A")
+		fs.writeFileSync(path.join(tmpRoot, "content", "alpha", "nested", "deep.mdx"), "# Deep")
+
+		await Effect.runPromise(generateContentPaths().pipe(Effect.provide(testLayers)))
+
+		const outPath = path.join(tmpRoot, "types", "generated", "content-paths.gen.ts")
+		const written = fs.readFileSync(outPath, "utf-8")
+
+		expect(written).toContain("content directory scanned: content")
+		expect(written).toContain("export type AlphaPaths =")
+		expect(written).toContain("content/alpha/first")
+		expect(written).toContain("content/alpha/nested/deep")
+		expect(written).toContain("export type BetaPaths =")
+		expect(written).toContain("content/beta/second")
+		// Directories processed in localeCompare order: alpha before beta; literals sorted
+		const alphaIdx = written.indexOf("export type AlphaPaths")
+		const betaIdx = written.indexOf("export type BetaPaths")
+		expect(alphaIdx).toBeLessThan(betaIdx)
+		expect(written).toMatch(
+			/export type ContentPaths = AlphaPaths \| BetaPaths;\n$/,
+		)
+
+		await Effect.runPromise(generateContentPaths().pipe(Effect.provide(testLayers)))
+		const second = fs.readFileSync(outPath, "utf-8")
+		expect(second).toBe(written)
+	})
+
+	it("strips .mdx extension and escapes double quotes in path literals", async () => {
+		fs.mkdirSync(path.join(tmpRoot, "content", "q"), { recursive: true })
+		fs.writeFileSync(path.join(tmpRoot, "content", 'q', 'say "hi".mdx'), "# x")
+
+		await Effect.runPromise(generateContentPaths().pipe(Effect.provide(testLayers)))
+
+		const written = fs.readFileSync(
+			path.join(tmpRoot, "types", "generated", "content-paths.gen.ts"),
+			"utf-8",
+		)
+		expect(written).toContain(String.raw`content/q/say \"hi\"`)
+	})
+})

--- a/tests/scripts/generate-image-paths.test.ts
+++ b/tests/scripts/generate-image-paths.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { NodeServices } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { TestClock } from "effect/testing"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { generateImagePaths } from "@/scripts/generate-image-paths"
+
+const testLayers = Layer.mergeAll(TestClock.layer(), NodeServices.layer)
+
+describe("scripts/generate-image-paths", () => {
+	let prevCwd: string
+	let tmpRoot: string
+
+	beforeEach(() => {
+		vi.useFakeTimers({ now: new Date("2024-06-15T12:00:00.000Z") })
+		prevCwd = process.cwd()
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gen-image-paths-"))
+		process.chdir(tmpRoot)
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		process.chdir(prevCwd)
+		fs.rmSync(tmpRoot, { recursive: true, force: true })
+	})
+
+	it("fails when the public directory is missing", async () => {
+		await expect(
+			Effect.runPromise(
+				generateImagePaths().pipe(
+					Effect.provide(testLayers),
+					Effect.flip,
+				),
+			),
+		).resolves.toMatch(/Public directory does not exist/)
+	})
+
+	it("emits RootImagePath, per-directory types in stable order, and a stable ImagePaths union", async () => {
+		fs.mkdirSync(path.join(tmpRoot, "public", "icons"), { recursive: true })
+		fs.writeFileSync(path.join(tmpRoot, "public", "root-a.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+		fs.writeFileSync(path.join(tmpRoot, "public", "icons", "b.jpg"), Buffer.from([0xff, 0xd8, 0xff]))
+		fs.writeFileSync(path.join(tmpRoot, "public", "icons", "a.webp"), Buffer.from([0x52, 0x49, 0x46, 0x46]))
+
+		await Effect.runPromise(generateImagePaths().pipe(Effect.provide(testLayers)))
+
+		const outPath = path.join(tmpRoot, "types", "generated", "image-paths.gen.ts")
+		const written = fs.readFileSync(outPath, "utf-8")
+
+		expect(written).toContain("public directory scanned: public")
+		expect(written).toContain("export type RootImagePath =")
+		expect(written).toContain("'/root-a.png'")
+		expect(written).toContain("export type IconsImagePath =")
+		expect(written).toContain("'/icons/a.webp'")
+		expect(written).toContain("'/icons/b.jpg'")
+		const iconsIdx = written.indexOf("export type IconsImagePath")
+		const rootIdx = written.indexOf("export type RootImagePath")
+		expect(rootIdx).toBeLessThan(iconsIdx)
+		expect(written).toMatch(
+			/export type ImagePaths = RootImagePath \| IconsImagePath;\n$/,
+		)
+
+		await Effect.runPromise(generateImagePaths().pipe(Effect.provide(testLayers)))
+		expect(fs.readFileSync(outPath, "utf-8")).toBe(written)
+	})
+
+	it("escapes single quotes in path literals", async () => {
+		fs.mkdirSync(path.join(tmpRoot, "public", "icons"), { recursive: true })
+		fs.writeFileSync(
+			path.join(tmpRoot, "public", "icons", "it's-fine.png"),
+			Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+		)
+
+		await Effect.runPromise(generateImagePaths().pipe(Effect.provide(testLayers)))
+
+		const written = fs.readFileSync(
+			path.join(tmpRoot, "types", "generated", "image-paths.gen.ts"),
+			"utf-8",
+		)
+		expect(written).toContain("'/icons/it\\'s-fine.png'")
+	})
+})

--- a/tests/scripts/generate-last-modified.test.ts
+++ b/tests/scripts/generate-last-modified.test.ts
@@ -1,0 +1,138 @@
+import type * as ChildProcess from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import * as NodePath from "@effect/platform-node/NodePath"
+import { NodeServices } from "@effect/platform-node"
+import { Effect, FileSystem, Layer, MutableHashSet } from "effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { decodeLastModifiedData } from "@/utils/validation-schemas"
+
+const { mockExecSync } = vi.hoisted(() => ({
+	mockExecSync: vi.fn(() => ""),
+}))
+
+vi.mock("node:child_process", () => ({
+	execSync: mockExecSync as unknown as typeof ChildProcess.execSync,
+}))
+
+import { generateLastModified, getAllContentFiles, parseGitBatchOutput } from "@/scripts/generate-last-modified"
+
+const testLayer = NodeServices.layer
+
+describe("scripts/generate-last-modified parseGitBatchOutput", () => {
+	it("maps added/modified lines to git timestamps and fills missing files with current time", async () => {
+		const repoRoot = "/repo"
+		const allFiles = MutableHashSet.empty<string>()
+		MutableHashSet.add(allFiles, `${repoRoot}/content/maps/foo.mdx`)
+		MutableHashSet.add(allFiles, `${repoRoot}/content/zombies/bar.mdx`)
+
+		const gitOut = `1700000000
+A\tcontent/maps/foo.mdx
+`
+
+		const result = await Effect.runPromise(
+			parseGitBatchOutput(gitOut, allFiles, repoRoot).pipe(Effect.provide(testLayer)),
+		)
+
+		expect(result["maps/foo.mdx"]?.lastModified).toBe(1700000000 * 1000)
+		expect(result["zombies/bar.mdx"]).toBeDefined()
+		expect(result["zombies/bar.mdx"]!.lastModified).not.toBe(result["maps/foo.mdx"]!.lastModified)
+	})
+
+	it("is deterministic for the same git output", async () => {
+		const repoRoot = "/repo"
+		const allFiles = MutableHashSet.empty<string>()
+		MutableHashSet.add(allFiles, `${repoRoot}/content/a/x.mdx`)
+		const gitOut = `1600000000
+M\tcontent/a/x.mdx
+`
+		const a = await Effect.runPromise(
+			parseGitBatchOutput(gitOut, allFiles, repoRoot).pipe(Effect.provide(testLayer)),
+		)
+		const b = await Effect.runPromise(
+			parseGitBatchOutput(gitOut, allFiles, repoRoot).pipe(Effect.provide(testLayer)),
+		)
+		expect(a).toEqual(b)
+	})
+})
+
+describe("scripts/generate-last-modified getAllContentFiles", () => {
+	let prevCwd: string
+	let tmpRoot: string
+
+	beforeEach(() => {
+		prevCwd = process.cwd()
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gen-last-mod-"))
+		process.chdir(tmpRoot)
+		fs.mkdirSync(path.join(tmpRoot, "content", "maps"), { recursive: true })
+		fs.writeFileSync(path.join(tmpRoot, "content", "maps", "a.mdx"), "# a")
+	})
+
+	afterEach(() => {
+		process.chdir(prevCwd)
+		fs.rmSync(tmpRoot, { recursive: true, force: true })
+	})
+
+	it("collects mdx paths under content subfolders", async () => {
+		const files = await Effect.runPromise(
+			getAllContentFiles(path.join(tmpRoot, "content")).pipe(Effect.provide(testLayer)),
+		)
+		const arr = [...files].map(p => p.replace(/\\/g, "/"))
+		expect(arr).toEqual([`${tmpRoot}/content/maps/a.mdx`.replace(/\\/g, "/")])
+	})
+
+})
+
+describe("scripts/generate-last-modified getAllContentFiles duplicate detection", () => {
+	it("fails when the same relative mdx path is counted more than once", async () => {
+		const dupFs = FileSystem.layerNoop({
+			readDirectory: (p: string) => {
+				const n = p.replace(/\\/g, "/")
+				if (n.endsWith("/content")) return Effect.succeed(["maps"])
+				if (n.endsWith("/content/maps")) return Effect.succeed(["a.mdx", "a.mdx"])
+				return Effect.succeed([])
+			},
+		})
+		const layer = Layer.mergeAll(dupFs, NodePath.layer)
+
+		const err = await Effect.runPromise(
+			getAllContentFiles("/tmp/content").pipe(Effect.provide(layer), Effect.flip),
+		)
+		expect(err).toMatchObject({ _tag: "DuplicateFilenameError" })
+	})
+})
+
+describe("scripts/generate-last-modified integration (mocked git)", () => {
+	let prevCwd: string
+	let tmpRoot: string
+
+	beforeEach(() => {
+		prevCwd = process.cwd()
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gen-last-mod-int-"))
+		process.chdir(tmpRoot)
+		fs.mkdirSync(path.join(tmpRoot, "content", "maps"), { recursive: true })
+		fs.mkdirSync(path.join(tmpRoot, "data"), { recursive: true })
+		fs.writeFileSync(path.join(tmpRoot, "content", "maps", "a.mdx"), "# hello")
+		mockExecSync.mockReturnValue(
+			`1704067200
+M\tcontent/maps/a.mdx
+`,
+		)
+	})
+
+	afterEach(() => {
+		mockExecSync.mockReset()
+		process.chdir(prevCwd)
+		fs.rmSync(tmpRoot, { recursive: true, force: true })
+	})
+
+	it("writes valid last-modified.json with encoded file metadata", async () => {
+		await Effect.runPromise(generateLastModified.pipe(Effect.provide(testLayer)))
+
+		const raw = fs.readFileSync(path.join(tmpRoot, "data", "last-modified.json"), "utf-8")
+		const decoded = await Effect.runPromise(decodeLastModifiedData(raw))
+		expect(decoded.version).toBe("1.0")
+		expect(decoded.files["maps/a.mdx"]?.lastModified).toBe(1704067200 * 1000)
+	})
+})

--- a/tests/scripts/generate-og-images.test.ts
+++ b/tests/scripts/generate-og-images.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { NodeServices } from "@effect/platform-node"
+import { Effect } from "effect"
+import { Command } from "effect/unstable/cli"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { generateOgCommand } from "@/scripts/generate-og-images"
+
+const runOg = Command.runWith(generateOgCommand, { version: "1.0.0" })
+const testLayer = NodeServices.layer
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+
+describe("scripts/generate-og-images CLI", () => {
+	let prevCwd: string
+	let tmpRoot: string
+
+	beforeEach(() => {
+		prevCwd = process.cwd()
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "og-cli-"))
+		process.chdir(tmpRoot)
+	})
+
+	afterEach(() => {
+		process.chdir(prevCwd)
+		fs.rmSync(tmpRoot, { recursive: true, force: true })
+	})
+
+	it("fails when no mode is selected", async () => {
+		const err = await Effect.runPromise(
+			runOg([]).pipe(Effect.provide(testLayer), Effect.flip),
+		)
+		expect(err).toMatchObject({ _tag: "OgCliError" })
+	})
+
+	it("fails when multiple modes are selected", async () => {
+		const err = await Effect.runPromise(
+			runOg(["--maps", "--zombies"]).pipe(Effect.provide(testLayer), Effect.flip),
+		)
+		expect(err).toMatchObject({ _tag: "OgCliError" })
+	})
+
+	it("fails when --zombies and --zombie are both used", async () => {
+		const err = await Effect.runPromise(
+			runOg(["--zombies", "--zombie", "some-zombie"]).pipe(Effect.provide(testLayer), Effect.flip),
+		)
+		expect(err).toMatchObject({ _tag: "OgCliError" })
+	})
+
+	it("fails when --map is used with --zombie (single)", async () => {
+		const err = await Effect.runPromise(
+			runOg(["--zombie", "some-zombie", "--map", "ascension"]).pipe(
+				Effect.provide(testLayer),
+				Effect.flip,
+			),
+		)
+		expect(err).toMatchObject({ _tag: "OgCliError" })
+	})
+
+	it("fails when --quests and --quest are both used", async () => {
+		const err = await Effect.runPromise(
+			runOg(["--quests", "--quest", "some-quest"]).pipe(Effect.provide(testLayer), Effect.flip),
+		)
+		expect(err).toMatchObject({ _tag: "OgCliError" })
+	})
+
+	it("fails when --map is used with --quest (single)", async () => {
+		const err = await Effect.runPromise(
+			runOg(["--quest", "some-quest", "--map", "ascension"]).pipe(
+				Effect.provide(testLayer),
+				Effect.flip,
+			),
+		)
+		expect(err).toMatchObject({ _tag: "OgCliError" })
+	})
+
+	it("fails when --maps and --map are combined", async () => {
+		const err = await Effect.runPromise(
+			runOg(["--maps", "--map", "ascension"]).pipe(Effect.provide(testLayer), Effect.flip),
+		)
+		expect(err).toMatchObject({ _tag: "OgCliError" })
+	})
+
+})
+
+describe("scripts/generate-og-images CLI (repo root)", () => {
+	let prevCwd: string
+
+	beforeEach(() => {
+		prevCwd = process.cwd()
+		process.chdir(repoRoot)
+	})
+
+	afterEach(() => {
+		process.chdir(prevCwd)
+	})
+
+	it("writes a main-quest OG image for --map ascension", async () => {
+		const out = fs.mkdtempSync(path.join(os.tmpdir(), "og-out-"))
+		await Effect.runPromise(
+			runOg(["--map", "ascension", "--output-dir", out]).pipe(Effect.provide(testLayer)),
+		)
+		const jpg = path.join(out, "main-quests", "opengraph-ascension.jpg")
+		expect(fs.existsSync(jpg)).toBe(true)
+		expect(fs.statSync(jpg).size).toBeGreaterThan(0)
+		const first = fs.readFileSync(jpg)
+
+		await Effect.runPromise(
+			runOg(["--map", "ascension", "--output-dir", out]).pipe(Effect.provide(testLayer)),
+		)
+		expect(fs.readFileSync(jpg).equals(first)).toBe(true)
+
+		fs.rmSync(out, { recursive: true, force: true })
+	})
+})

--- a/tests/scripts/image-optimization.test.ts
+++ b/tests/scripts/image-optimization.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { NodeServices } from "@effect/platform-node"
+import { Effect, Exit } from "effect"
+import { Command } from "effect/unstable/cli"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { optimizeCommand } from "@/scripts/image-optimization"
+
+const runOptimize = Command.runWith(optimizeCommand, { version: "1.0.0" })
+
+const testLayer = NodeServices.layer
+
+/** Minimal valid 1×1 PNG */
+const tinyPng = Buffer.from(
+	"89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6300010000050001",
+	"hex",
+)
+
+describe("scripts/image-optimization CLI", () => {
+	let prevCwd: string
+	let tmpRoot: string
+
+	beforeEach(() => {
+		prevCwd = process.cwd()
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "img-opt-"))
+		process.chdir(tmpRoot)
+	})
+
+	afterEach(() => {
+		process.chdir(prevCwd)
+		fs.rmSync(tmpRoot, { recursive: true, force: true })
+	})
+
+	it("requires --output-dir", async () => {
+		const exit = await Effect.runPromiseExit(runOptimize([]).pipe(Effect.provide(testLayer)))
+		expect(Exit.isFailure(exit)).toBe(true)
+	})
+
+	it("optimizes a PNG into webp in the output dir and moves source to oldassets", async () => {
+		fs.mkdirSync(path.join(tmpRoot, "newassets"), { recursive: true })
+		fs.writeFileSync(path.join(tmpRoot, "newassets", "photo.png"), tinyPng)
+
+		await Effect.runPromise(
+			runOptimize(["--output-dir", "out"]).pipe(Effect.provide(testLayer)),
+		)
+
+		const outFiles = fs.readdirSync(path.join(tmpRoot, "out"))
+		expect(outFiles).toEqual(["photo.webp"])
+		expect(fs.existsSync(path.join(tmpRoot, "newassets", "photo.png"))).toBe(false)
+		expect(fs.existsSync(path.join(tmpRoot, "oldassets", "photo.png"))).toBe(true)
+	})
+
+	it("is deterministic: same input produces identical output bytes", async () => {
+		fs.mkdirSync(path.join(tmpRoot, "newassets"), { recursive: true })
+		fs.writeFileSync(path.join(tmpRoot, "newassets", "photo.png"), tinyPng)
+
+		await Effect.runPromise(
+			runOptimize(["--output-dir", "out1", "--source-dir", "newassets"]).pipe(
+				Effect.provide(testLayer),
+			),
+		)
+		const first = fs.readFileSync(path.join(tmpRoot, "out1", "photo.webp"))
+
+		fs.mkdirSync(path.join(tmpRoot, "newassets2"), { recursive: true })
+		fs.writeFileSync(path.join(tmpRoot, "newassets2", "photo.png"), tinyPng)
+		await Effect.runPromise(
+			runOptimize(["--output-dir", "out2", "--source-dir", "newassets2"]).pipe(
+				Effect.provide(testLayer),
+			),
+		)
+		const second = fs.readFileSync(path.join(tmpRoot, "out2", "photo.webp"))
+
+		expect(second.equals(first)).toBe(true)
+	})
+
+	it("accepts --map, --preview, and --no-resize flags without throwing", async () => {
+		for (const extra of [
+			["--map"],
+			["--preview"],
+			["--no-resize"],
+		] as const) {
+			const src = `newassets-${extra[0].replace(/^--/, "")}`
+			fs.mkdirSync(path.join(tmpRoot, src), { recursive: true })
+			fs.writeFileSync(path.join(tmpRoot, src, "photo.png"), tinyPng)
+			const out = path.join(tmpRoot, `out-${extra[0]}`)
+			fs.mkdirSync(out, { recursive: true })
+			await Effect.runPromise(
+				runOptimize(["--output-dir", out, "--source-dir", src, ...extra]).pipe(
+					Effect.provide(testLayer),
+				),
+			)
+			expect(fs.readdirSync(out).length).toBeGreaterThan(0)
+		}
+	})
+})

--- a/tests/scripts/scripts-utils.test.ts
+++ b/tests/scripts/scripts-utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+import { SUPPORTED_IMAGE_FORMATS } from "@/scripts/utils"
+
+describe("scripts/utils", () => {
+	it("SUPPORTED_IMAGE_FORMATS includes expected extensions only", () => {
+		expect([...SUPPORTED_IMAGE_FORMATS].sort()).toEqual([
+			".avif",
+			".jpeg",
+			".jpg",
+			".png",
+			".webp",
+		])
+	})
+})

--- a/tests/utils/server-functions.test.ts
+++ b/tests/utils/server-functions.test.ts
@@ -1,4 +1,4 @@
-import * as BunPath from "@effect/platform-bun/BunPath"
+import * as NodePath from "@effect/platform-node/NodePath"
 import { expect, it, layer } from "@effect/vitest"
 import { Effect, FileSystem, Layer, Redacted } from "effect"
 import { afterEach, beforeEach, describe, vi } from "vitest"
@@ -33,7 +33,7 @@ const MockFileSystemLayer = Layer.mergeAll(
 	FileSystem.layerNoop({
 		readFileString: () => Effect.succeed(MOCK_LAST_MODIFIED_JSON),
 	}),
-	BunPath.layer,
+	NodePath.layer,
 )
 
 describe("getServerUrl", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Vitest coverage for the custom repo scripts under `scripts/`, with one test file per script (plus `scripts/utils.ts`). Scripts now export their runnable Effect programs and only invoke `NodeRuntime.runMain` when `import.meta.main` is true, so tests can import logic without side effects.

## Key changes

- **Runtime**: Replaced `@effect/platform-bun` with `@effect/platform-node` for scripts and `PageRuntime` (`lib/layers.ts`) so Node/Vitest can load the same code paths without the Bun-only dependency graph. `package.json` scripts still run via `bun scripts/...`.
- **Tests**: New files under `tests/scripts/` cover deterministic generated unions, `parseGitBatchOutput` / `getAllContentFiles` (including duplicate error), mocked `execSync` integration for `generate-last-modified`, `Command.runWith` for image optimization and OG image CLIs, and a happy-path OG generation from the real repo root when assets exist.

## Verification

- `bun run test`
- `bun run lint`
- `bun run typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9144722b-e97a-4010-bc5a-6cbd7876e8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9144722b-e97a-4010-bc5a-6cbd7876e8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

