### PR TITLE
fix: remove timestamps from gen file

### DIFF
--- a/scripts/generate-image-paths.ts
+++ b/scripts/generate-image-paths.ts
@@ -109,18 +109,6 @@ function generateTypeForDir(typeName: string, imagePaths: string[]) {
 	return `export type ${typeName} =\n  ${literals.join(" |\n  ")};\n`
 }
 
-function headerComment(publicDir: string, duration: string | number) {
-	const now = new Date().toISOString()
-	return `/**
- * THIS FILE IS AUTO-GENERATED.
- * Run 'generate:image:paths' to regenerate.
- *
- * public directory scanned: ${publicDir}
- * generated at: ${now}
- * generated in: ${duration}ms
- */\n\n`
-}
-
 /** @param cwd - Workspace root (must contain `public/` when run). */
 export const generateImagePaths = Effect.fn("generateImagePaths")(function* (
 	cwd: string = process.cwd(),
@@ -161,7 +149,10 @@ export const generateImagePaths = Effect.fn("generateImagePaths")(function* (
 	)
 
 	const lines: string[] = []
-	lines.push(headerComment(path.relative(cwd, publicDir), durationMs))
+	lines.push(`/**
+ * THIS FILE IS AUTO-GENERATED.
+ * Run 'generate:image:paths' to regenerate.
+ */\n`)
 	// root images type
 	lines.push("/** Union of images located directly in `/public (root)` */\n")
 	lines.push(generateTypeForDir("RootImagePath", rootWebPaths))

--- a/types/generated/image-paths.gen.ts
+++ b/types/generated/image-paths.gen.ts
@@ -1,10 +1,6 @@
 /**
  * THIS FILE IS AUTO-GENERATED.
  * Run 'generate:image:paths' to regenerate.
- *
- * public directory scanned: public
- * generated at: 2026-04-03T09:30:59.413Z
- * generated in: 47ms
  */
 
 /** Union of images located directly in `/public (root)` */


### PR DESCRIPTION
Removes the timestamp and duration logging in the image-paths gen file to avoid creating unneccessary diffs when none of the image paths have changed.