### PR TITLE
update: GLOBAL_OG_PROPS to use proper metadata type definition

### DIFF
--- a/app/bestiary/[id]/page.tsx
+++ b/app/bestiary/[id]/page.tsx
@@ -67,7 +67,7 @@ export const generateMetadata = async ({
 			title: zombie.title,
 			description,
 			openGraph: {
-				...GLOBAL_OG_PROPS.openGraph,
+				...GLOBAL_OG_PROPS,
 				title: zombie.title,
 				description,
 				url: `/bestiary/${zombie.id}`,

--- a/app/bestiary/page.tsx
+++ b/app/bestiary/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 	description:
 		"Discover the weaknesses, behavior, and strategies for defeating all enemy types in Call of Duty: Zombies.",
 	openGraph: {
-		...GLOBAL_OG_PROPS.openGraph,
+		...GLOBAL_OG_PROPS,
 		title: "Bestiary",
 		description:
 			"Discover the weaknesses, behavior, and strategies for defeating all enemy types in Call of Duty: Zombies.",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
 	},
 	category: "gaming",
 	openGraph: {
-		...GLOBAL_OG_PROPS.openGraph,
+		...GLOBAL_OG_PROPS,
 		title: {
 			template: `%s - ${SITE_TITLE}`,
 			default: SITE_TITLE,

--- a/app/main-quests/[game]/[map]/page.tsx
+++ b/app/main-quests/[game]/[map]/page.tsx
@@ -54,7 +54,7 @@ export const generateMetadata = async ({
 			title,
 			description,
 			openGraph: {
-				...GLOBAL_OG_PROPS.openGraph,
+				...GLOBAL_OG_PROPS,
 				title,
 				description,
 				url: `/main-quests/${quest.game}/${quest.id}`,

--- a/app/main-quests/page.tsx
+++ b/app/main-quests/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 	description:
 		"Learn how to complete all main quests/easter eggs in COD Zombies with our detailed step-by-step guides.",
 	openGraph: {
-		...GLOBAL_OG_PROPS.openGraph,
+		...GLOBAL_OG_PROPS,
 		title: "Main Quests",
 		description:
 			"Learn how to complete all main quests/easter eggs in COD Zombies with our detailed step-by-step guides.",

--- a/app/maps/[id]/page.tsx
+++ b/app/maps/[id]/page.tsx
@@ -34,7 +34,7 @@ export const generateMetadata = async ({ params }: PageProps<"/maps/[id]">): Pro
 		title,
 		description: map.value.description,
 		openGraph: {
-			...GLOBAL_OG_PROPS.openGraph,
+			...GLOBAL_OG_PROPS,
 			title,
 			description: map.value.description,
 			url: `/maps/${map.value.id}`,

--- a/app/maps/page.tsx
+++ b/app/maps/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 	description:
 		"Interactive maps for Call of Duty: Zombies showcasing locations of weapons, perks, objectives, and more to help guide your experience.",
 	openGraph: {
-		...GLOBAL_OG_PROPS.openGraph,
+		...GLOBAL_OG_PROPS,
 		title: "Interactive Maps",
 		description:
 			"Interactive maps for Call of Duty: Zombies showcasing locations of weapons, perks, objectives, and more to help guide your experience.",

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 	description:
 		"Learn about how we collect, use, and protect your personal information. Our privacy policy outlines our commitment to safeguarding your data and privacy rights.",
 	openGraph: {
-		...GLOBAL_OG_PROPS.openGraph,
+		...GLOBAL_OG_PROPS,
 		title: "Privacy Policy",
 		description:
 			"Learn about how we collect, use, and protect your personal information. Our privacy policy outlines our commitment to safeguarding your data and privacy rights.",

--- a/app/relics/[game]/[id]/page.tsx
+++ b/app/relics/[game]/[id]/page.tsx
@@ -55,7 +55,7 @@ export const generateMetadata = async ({
 		title,
 		description,
 		openGraph: {
-			...GLOBAL_OG_PROPS.openGraph,
+			...GLOBAL_OG_PROPS,
 			title,
 			description,
 			url: `/relics/${game}/${id}`,

--- a/app/relics/page.tsx
+++ b/app/relics/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 	title: "Cursed Relics",
 	description: "Learn how to unlock the most desired relics in Black Ops 7's Cursed mode.",
 	openGraph: {
-		...GLOBAL_OG_PROPS.openGraph,
+		...GLOBAL_OG_PROPS,
 		title: "Cursed Relics",
 		description: "Learn how to unlock the most desired relics in Black Ops 7's Cursed mode.",
 		url: "/relics",

--- a/app/side-quests/[game]/[map]/[id]/page.tsx
+++ b/app/side-quests/[game]/[map]/[id]/page.tsx
@@ -63,7 +63,7 @@ export const generateMetadata = async ({
 			title,
 			description,
 			openGraph: {
-				...GLOBAL_OG_PROPS.openGraph,
+				...GLOBAL_OG_PROPS,
 				title,
 				description,
 				url: `/side-quests/${game}/${map}/${id}`,

--- a/app/side-quests/page.tsx
+++ b/app/side-quests/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 	description:
 		"Learn how to complete hidden Side Quests/Easter Eggs in COD Zombies with our detailed step-by-step guides.",
 	openGraph: {
-		...GLOBAL_OG_PROPS.openGraph,
+		...GLOBAL_OG_PROPS,
 		title: "Side Quests",
 		description:
 			"Learn how to complete hidden Side Quests/Easter Eggs in COD Zombies with our detailed step-by-step guides.",

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -19,11 +19,9 @@ export const CARD_LIMIT = 12
 /** Limit for the amount of preview cards shown per section on the home page */
 export const HOME_PREVIEW_LIMIT = 3
 /** Default Open Graph properties for the website */
-export const GLOBAL_OG_PROPS: Partial<Metadata> = {
-	openGraph: {
-		siteName: SITE_TITLE,
-		locale: "en_US",
-		type: "website",
-		emails: ["contact@codzombiesguides.com"],
-	},
+export const GLOBAL_OG_PROPS: Metadata["openGraph"] = {
+	siteName: SITE_TITLE,
+	locale: "en_US",
+	type: "website",
+	emails: ["contact@codzombiesguides.com"],
 }


### PR DESCRIPTION
Updates the type annotation of `GLOBAL_OG_PROPS` to be less strict and remove the need to use dot notation for access the properties.