### PR TITLE
remove: declarations module

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,4 +1,0 @@
-declare module "*.css" {
-	const content: string
-	export default content
-}


### PR DESCRIPTION
Removes the `declarations.d.ts` file previously introduced with https://github.com/PlagueFPS/cod-zombies/pull/225 for the purpose of getting TypeScript intellisense for `.css` files when using TSGO. We are no longer using TSGO outside of CI for typechecking so this file is no longer needed.