### PR TITLE
fix: wrong hotkey for toggling map sidebar

### DIFF
--- a/components/client/back-to-top-button.tsx
+++ b/components/client/back-to-top-button.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys"
+import { useHotkey } from "@tanstack/react-hotkeys"
 import { Shortcut } from "@/components/client/shortcut"
 import { Button, type ButtonProps } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -43,7 +43,7 @@ export function BackToTopButton({
 			</TooltipTrigger>
 			<TooltipContent side="bottom" sideOffset={6}>
 				<div className="flex items-center gap-1">
-					<Shortcut shortcut={formatForDisplay("Alt+T")} size="sm" variant="ghost" />
+					<Shortcut shortcut="Alt+T" size="sm" variant="ghost" />
 					<span>to scroll to top</span>
 				</div>
 			</TooltipContent>

--- a/components/client/contact-form.tsx
+++ b/components/client/contact-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useForm } from "@tanstack/react-form"
-import { formatForDisplay, useHotkeys } from "@tanstack/react-hotkeys"
+import { useHotkeys } from "@tanstack/react-hotkeys"
 import { CircleAlert, Loader2, Mail, Send } from "lucide-react"
 import { useState, useTransition } from "react"
 import { toast } from "sonner"
@@ -61,7 +61,11 @@ export default function ContactForm({ className }: ContactFormProps) {
 
 	useHotkeys([
 		{ hotkey: "C", callback: () => handleOpenChange(!open) },
-		{ hotkey: "Mod+Enter", callback: () => form.handleSubmit(), options: { enabled: open } },
+		{
+			hotkey: "Mod+Enter",
+			callback: () => form.handleSubmit(),
+			options: { enabled: open, conflictBehavior: "allow" },
+		},
 	])
 
 	const handleSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {
@@ -211,7 +215,7 @@ export default function ContactForm({ className }: ContactFormProps) {
 							</TooltipTrigger>
 							<TooltipContent side="bottom" sideOffset={6} className="z-999">
 								<div className="flex items-center gap-1">
-									<Shortcut shortcut={formatForDisplay("Mod+Enter")} size="sm" />
+									<Shortcut shortcut="Mod+Enter" size="sm" />
 									<span>to submit contact form</span>
 								</div>
 							</TooltipContent>

--- a/components/client/custom-sidebar-trigger.tsx
+++ b/components/client/custom-sidebar-trigger.tsx
@@ -1,5 +1,4 @@
 "use client"
-import { formatForDisplay } from "@tanstack/react-hotkeys"
 import { PanelLeftOpenIcon } from "lucide-react"
 import { Shortcut } from "@/components/client/shortcut"
 import { Button } from "@/components/ui/button"
@@ -34,7 +33,7 @@ export function CustomSideBarTrigger({ className }: ICustomSidebarTrigger) {
 		>
 			<PanelLeftOpenIcon className="size-5 transition-all" />
 			<span className="sr-only">Toggle Sidebar</span>
-			{!isMobile && <Shortcut shortcut={formatForDisplay("Mod+B")} size="sm" variant="ghost" />}
+			{!isMobile && <Shortcut shortcut="Mod+B" size="sm" variant="ghost" />}
 		</Button>
 	)
 }

--- a/components/client/feedback-form.tsx
+++ b/components/client/feedback-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useForm } from "@tanstack/react-form"
-import { formatForDisplay, useHotkeys } from "@tanstack/react-hotkeys"
+import { useHotkeys } from "@tanstack/react-hotkeys"
 import { Cause, Exit } from "effect"
 import { CircleAlert, MessageCircleHeart, Send } from "lucide-react"
 import { useState, useTransition } from "react"
@@ -79,7 +79,11 @@ export function FeedbackForm({ className, ...props }: FeedbackFormProps) {
 
 	useHotkeys([
 		{ hotkey: "F", callback: () => handleOpenChange(!open) },
-		{ hotkey: "Mod+Enter", callback: () => form.handleSubmit(), options: { enabled: open } },
+		{
+			hotkey: "Mod+Enter",
+			callback: () => form.handleSubmit(),
+			options: { enabled: open, conflictBehavior: "allow" },
+		},
 	])
 
 	const handleSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {
@@ -196,7 +200,7 @@ export function FeedbackForm({ className, ...props }: FeedbackFormProps) {
 								</TooltipTrigger>
 								<TooltipContent side="bottom" sideOffset={6}>
 									<div className="flex items-center gap-1">
-										<Shortcut shortcut={formatForDisplay("Mod+Enter")} size="sm" />
+										<Shortcut shortcut="Mod+Enter" size="sm" />
 										<span>to submit feedback</span>
 									</div>
 								</TooltipContent>

--- a/components/client/map-settings-panel.tsx
+++ b/components/client/map-settings-panel.tsx
@@ -1,4 +1,4 @@
-import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys"
+import { useHotkey } from "@tanstack/react-hotkeys"
 import { CornerUpLeft, MapIcon, MapPin, MessageSquare, SettingsIcon } from "lucide-react"
 import { useState } from "react"
 import { Shortcut } from "@/components/client/shortcut"
@@ -86,7 +86,7 @@ export default function MapSettingsPanel() {
 					sideOffset={5}
 					className="z-999 flex items-center justify-center gap-2"
 				>
-					<Shortcut shortcut={formatForDisplay("Mod+/")} size="sm" variant="ghost" />
+					<Shortcut shortcut="Mod+/" size="sm" variant="ghost" />
 					<span>Map Settings</span>
 				</TooltipContent>
 			</Tooltip>
@@ -412,7 +412,7 @@ export default function MapSettingsPanel() {
 					{!isMobile ? (
 						<div className="mr-auto flex items-center justify-center gap-1 text-sm text-muted-foreground">
 							<span>Shortcut:</span>
-							<Shortcut shortcut={formatForDisplay("Mod+/")} size="sm" />
+							<Shortcut shortcut="Mod+/" size="sm" />
 						</div>
 					) : null}
 					<Button variant={"destructive"} onClick={() => handleOpenChange(false)}>

--- a/components/client/newsletter-form.tsx
+++ b/components/client/newsletter-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useForm } from "@tanstack/react-form"
-import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys"
+import { useHotkey } from "@tanstack/react-hotkeys"
 import { useRef, useTransition } from "react"
 import { toast } from "sonner"
 import { Shortcut } from "@/components/client/shortcut"
@@ -107,7 +107,7 @@ export default function NewsletterForm() {
 													</TooltipTrigger>
 													<TooltipContent side="top" sideOffset={6}>
 														<div className="flex items-center gap-1">
-															<Shortcut shortcut={formatForDisplay("Mod+Enter")} size="sm" />
+															<Shortcut shortcut="Mod+Enter" size="sm" />
 															<span>to subscribe</span>
 														</div>
 													</TooltipContent>

--- a/components/client/search-bar-input.tsx
+++ b/components/client/search-bar-input.tsx
@@ -1,6 +1,6 @@
 "use client"
 import type { Route } from "next"
-import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys"
+import { useHotkey } from "@tanstack/react-hotkeys"
 import {
 	ArrowDownIcon,
 	ArrowUpIcon,
@@ -75,7 +75,7 @@ export function SearchBarInput({ searchItems }: SearchInputProps) {
 			>
 				<Search className="size-5" />
 				<span className="mr-auto text-sm">Search</span>
-				<Shortcut shortcut={formatForDisplay("Mod+K")} size="sm" />
+				<Shortcut shortcut="Mod+K" size="sm" />
 			</CommandDialogTrigger>
 			<CommandDialogPopup>
 				<Command items={searchItems}>
@@ -126,7 +126,7 @@ export function SearchBarInput({ searchItems }: SearchInputProps) {
 							</div>
 						</div>
 						<div className="flex items-center gap-2">
-							<Shortcut shortcut="Esc" size="sm" variant="outline" />
+							<Shortcut shortcut="Escape" size="sm" variant="outline" />
 							<span>Close</span>
 						</div>
 					</CommandFooter>

--- a/components/client/share-button.tsx
+++ b/components/client/share-button.tsx
@@ -44,7 +44,7 @@ export function ShareButton({ title, url, ...props }: ShareButtonProps) {
 		setOpen(false)
 	}
 
-	useHotkey("S", () => setOpen(prev => !prev))
+	useHotkey("S", () => setOpen(prev => !prev), { requireReset: true })
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>

--- a/components/client/shortcut.tsx
+++ b/components/client/shortcut.tsx
@@ -1,4 +1,5 @@
 import type React from "react"
+import { formatForDisplay, type RegisterableHotkey } from "@tanstack/react-hotkeys"
 import { cva } from "class-variance-authority"
 import { Children } from "react"
 import { Kbd, KbdGroup } from "@/components/ui/kbd"
@@ -11,10 +12,12 @@ interface ShortcutWithChildren {
 	variant?: "default" | "outline" | "ghost"
 	size?: "sm" | "md" | "lg"
 	shortcut?: never
+	useSymbols?: never
 }
 
 interface ShortcutWithShortcuts {
-	shortcut: string
+	shortcut: RegisterableHotkey
+	useSymbols?: boolean
 	children?: never
 	className?: string
 	variant?: "default" | "outline" | "ghost"
@@ -49,6 +52,7 @@ const shortcutVariants = cva(
 
 export function Shortcut({
 	shortcut,
+	useSymbols = true,
 	children,
 	className,
 	variant = "default",
@@ -59,7 +63,7 @@ export function Shortcut({
 	return (
 		<KbdGroup>
 			{shortcut ? (
-				<Kbd className={kbdClassName}>{shortcut}</Kbd>
+				<Kbd className={kbdClassName}>{formatForDisplay(shortcut, { useSymbols })}</Kbd>
 			) : (
 				Children.toArray(children).map((child, index) => {
 					const key = `shortcut-${index + 1}`

--- a/components/client/table-of-contents.tsx
+++ b/components/client/table-of-contents.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys"
+import { useHotkey } from "@tanstack/react-hotkeys"
 import { ChevronDown, ChevronUp } from "lucide-react"
 import Link from "next/link"
 import { useState } from "react"
@@ -64,7 +64,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
 									sideOffset={5}
 									className="z-999 flex items-center justify-center gap-2"
 								>
-									<Shortcut shortcut={formatForDisplay("Alt+C")} size="sm" variant="ghost" />
+									<Shortcut shortcut="Alt+C" size="sm" variant="ghost" />
 									<span>Toggle Expanded</span>
 								</TooltipContent>
 							</Tooltip>

--- a/components/client/theme-toggle.tsx
+++ b/components/client/theme-toggle.tsx
@@ -27,7 +27,7 @@ export default function ThemeToggle({ className }: ThemeToggleProps) {
 		})
 	}
 
-	useHotkey("T", () => handleThemeToggle())
+	useHotkey("T", () => handleThemeToggle(), { requireReset: true })
 
 	return (
 		<div className="flex w-fit p-0.5">

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -89,7 +89,7 @@ function SidebarProvider({
 	}, [isMobile, setOpen, setOpenMobile])
 
 	// Adds a keyboard shortcut to toggle the sidebar.
-	useHotkey("Mod+S", () => toggleSidebar())
+	useHotkey("Mod+B", () => toggleSidebar())
 
 	// We add a state so that we can do data-state="expanded" or "collapsed".
 	// This makes it easier to style the sidebar with Tailwind classes.


### PR DESCRIPTION
Fixes the map sidebar being triggered by `Mod+S`, instead of `Mod+B`. Also refactors the `Shortcut` component to accept a `RegisterableHotkey` as input to avoid having to call `formatForDisplay` everywhere.