### PR TITLE
fix: tests failing on Windows due to resource lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
         "@effect/vitest": "4.0.0-beta.43",
         "@react-email/preview-server": "^5.2.10",
         "@tailwindcss/postcss": "^4.2.2",
-        "@types/bun": "^1.3.11",
+        "@types/bun": "^1.3.14",
         "@types/leaflet": "^1.9.21",
         "@types/mdx": "^2.0.13",
         "@types/node": "^25.5.2",
@@ -534,7 +534,7 @@
 
     "@types/acorn": ["@types/acorn@4.0.6", "", { "dependencies": { "@types/estree": "*" } }, "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -696,7 +696,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001746", "", {}, "sha512-eA7Ys/DGw+pnkWWSE/id29f2IcPHVoE8wxtvE5JdvD2V28VTDPy1yEeo11Guz0sJ4ZeGRcm3uaTcAqK1LXaphA=="],
 
@@ -1445,8 +1445,6 @@
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.8.9", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-hY/u2lxLrbecMEWSB0IpGzGyDyeoMFQhCvZd2jGFSE5I17Fh01sYUBPCJtkWERw7zrac9+cIghxm/ytJa2X8iA=="],
-
-    "bun-types/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "engine.io/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"@effect/vitest": "4.0.0-beta.43",
 		"@react-email/preview-server": "^5.2.10",
 		"@tailwindcss/postcss": "^4.2.2",
-		"@types/bun": "^1.3.11",
+		"@types/bun": "^1.3.14",
 		"@types/leaflet": "^1.9.21",
 		"@types/mdx": "^2.0.13",
 		"@types/node": "^25.5.2",

--- a/tests/scripts/generate-content-paths.test.ts
+++ b/tests/scripts/generate-content-paths.test.ts
@@ -30,6 +30,7 @@ describe("generateContentPaths", () => {
 		const cause = expectExitFailure(exit)
 		expectCauseHasString(cause, "Content directory does not exist")
 		expect(Exit.isFailure(exit)).toBe(true)
+		process.chdir(prevCwd)
 		rmSync(root, { recursive: true, force: true })
 	})
 
@@ -66,6 +67,7 @@ describe("generateContentPaths", () => {
 		const unionIdx = out.indexOf("export type ContentPaths =")
 		expect(out.slice(unionIdx)).toMatch(/AlphaPaths\s*\|\s*ZebraPaths/)
 
+		process.chdir(prevCwd)
 		rmSync(root, { recursive: true, force: true })
 	})
 
@@ -82,6 +84,7 @@ describe("generateContentPaths", () => {
 		const out = readFileSync(join(root, "types", "generated", "content-paths.gen.ts"), "utf-8")
 		expect(out).toContain("export type EmptydirPaths = never;")
 
+		process.chdir(prevCwd)
 		rmSync(root, { recursive: true, force: true })
 	})
 })

--- a/tests/scripts/generate-image-paths.test.ts
+++ b/tests/scripts/generate-image-paths.test.ts
@@ -30,6 +30,7 @@ describe("generateImagePaths", () => {
 		const cause = expectExitFailure(exit)
 		expectCauseHasString(cause, "Public directory does not exist")
 		expect(Exit.isFailure(exit)).toBe(true)
+		process.chdir(prevCwd)
 		rmSync(root, { recursive: true, force: true })
 	})
 
@@ -85,6 +86,7 @@ describe("generateImagePaths", () => {
 		expect(out).not.toContain("ContentImagePath")
 		expect(out).not.toContain("OpengraphImagesImagePath")
 
+		process.chdir(prevCwd)
 		rmSync(root, { recursive: true, force: true })
 	})
 
@@ -105,6 +107,7 @@ describe("generateImagePaths", () => {
 		const out = readFileSync(join(root, "types", "generated", "image-paths.gen.ts"), "utf-8")
 		expect(out).toContain("\\'")
 
+		process.chdir(prevCwd)
 		rmSync(root, { recursive: true, force: true })
 	})
 })


### PR DESCRIPTION
The failures were `EBUSY: resource busy or locked on rmSync`. Each test did `process.chdir(root`) and then `rmSync(root, …)` while still inside root, which triggers that error. Linux/WSL is more permissive, so the tests could pass there. `process.chdir(prevCwd)` now runs immediately before `rmSync(root, …)` in every test that changes into the temp dir, so cleanup runs from outside the tree being deleted.