### PR TITLE
fix: mobile main quest guide breadcrumbs wrapping

### DIFF
--- a/components/client/breadcrumbs.tsx
+++ b/components/client/breadcrumbs.tsx
@@ -60,11 +60,7 @@ export function Breadcrumbs<T extends string>({ links, className }: BreadcrumbsP
 	const collapseAggressive = lastLen >= LONG_LAST_LABEL_CHARS
 
 	const menuLinks =
-		showEllipsis && collapseAggressive
-			? links.slice(0, -1)
-			: showEllipsis
-				? links.slice(1, -1)
-				: []
+		showEllipsis && collapseAggressive ? links.slice(0, -1) : showEllipsis ? links.slice(1, -1) : []
 
 	const trailPieces = trailAfterHome(links, showEllipsis, collapseAggressive)
 
@@ -76,14 +72,18 @@ export function Breadcrumbs<T extends string>({ links, className }: BreadcrumbsP
 				</BreadcrumbItem>
 				{trailPieces.map(entry => (
 					<Fragment
-						key={entry.kind === "link" ? `${entry.link.href}-${entry.link.title}` : "trail-ellipsis"}
+						key={
+							entry.kind === "link" ? `${entry.link.href}-${entry.link.title}` : "trail-ellipsis"
+						}
 					>
 						<BreadcrumbSeparator>
 							<Slash />
 						</BreadcrumbSeparator>
 						<BreadcrumbItem>
 							{entry.kind === "link" ? (
-								<BreadcrumbLink render={<NavLink href={entry.link.href}>{entry.link.title}</NavLink>} />
+								<BreadcrumbLink
+									render={<NavLink href={entry.link.href}>{entry.link.title}</NavLink>}
+								/>
 							) : (
 								<CustomEllipsis menuLinks={menuLinks} />
 							)}

--- a/components/client/breadcrumbs.tsx
+++ b/components/client/breadcrumbs.tsx
@@ -20,9 +20,32 @@ import {
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 
+/** Above this character count on the leaf label, omit the first trail segment on mobile so more fits on one line */
+const LONG_LAST_LABEL_CHARS = 24
+
 export interface Link<T extends string> {
 	href: Route<T>
 	title: string
+}
+
+type TrailPiece<T extends string> = { kind: "link"; link: Link<T> } | { kind: "ellipsis" }
+
+/** When `showEllipsis` is true, callers should pass `links.length >= 3`. */
+export function trailAfterHome<T extends string>(
+	links: Link<T>[],
+	showEllipsis: boolean,
+	collapseAggressive: boolean,
+): TrailPiece<T>[] {
+	if (!showEllipsis) {
+		return links.map(link => ({ kind: "link" as const, link }))
+	}
+
+	const last = links.at(-1)!
+	const head: TrailPiece<T>[] = []
+	if (!collapseAggressive) {
+		head.push({ kind: "link", link: links[0]! })
+	}
+	return [...head, { kind: "ellipsis" as const }, { kind: "link", link: last }]
 }
 
 interface BreadcrumbsProps<T extends string> {
@@ -32,8 +55,18 @@ interface BreadcrumbsProps<T extends string> {
 
 export function Breadcrumbs<T extends string>({ links, className }: BreadcrumbsProps<T>) {
 	const isMobile = useIsMobile(640)
-	const showEllipsis = links.length >= 4 && isMobile
-	const menuLinks = showEllipsis ? links.slice(0, -1) : []
+	const showEllipsis = links.length >= 3 && isMobile
+	const lastLen = links.at(-1)?.title.length ?? 0
+	const collapseAggressive = lastLen >= LONG_LAST_LABEL_CHARS
+
+	const menuLinks =
+		showEllipsis && collapseAggressive
+			? links.slice(0, -1)
+			: showEllipsis
+				? links.slice(1, -1)
+				: []
+
+	const trailPieces = trailAfterHome(links, showEllipsis, collapseAggressive)
 
 	return (
 		<Breadcrumb className={cn("mr-auto", className)}>
@@ -41,50 +74,22 @@ export function Breadcrumbs<T extends string>({ links, className }: BreadcrumbsP
 				<BreadcrumbItem>
 					<BreadcrumbLink render={<NavLink href="/">Home</NavLink>} />
 				</BreadcrumbItem>
-				{links.map((link, index) => {
-					// For the links cut-off by the ellipsis
-					if (showEllipsis && index === 1) {
-						return (
-							<Fragment key="links-ellipsis">
-								<BreadcrumbSeparator>
-									<Slash />
-								</BreadcrumbSeparator>
-								<BreadcrumbItem>
-									<CustomEllipsis menuLinks={menuLinks} />
-								</BreadcrumbItem>
-							</Fragment>
-						)
-					}
-
-					// skip rendering links cut-off by the ellipsis
-					if (showEllipsis && index < links.length - 1) return null
-
-					// For the last item in the array, does not matter if showEllipsis is true/false here
-					if (index === links.length - 1) {
-						return (
-							<Fragment key={`${link.title}-${link.href}`}>
-								<BreadcrumbSeparator>
-									<Slash />
-								</BreadcrumbSeparator>
-								<BreadcrumbItem>
-									<BreadcrumbLink render={<NavLink href={link.href}>{link.title}</NavLink>} />
-								</BreadcrumbItem>
-							</Fragment>
-						)
-					}
-
-					// For all items when showEllipsis is false
-					return (
-						<Fragment key={`${link.title}-${link.href}`}>
-							<BreadcrumbSeparator>
-								<Slash />
-							</BreadcrumbSeparator>
-							<BreadcrumbItem>
-								<BreadcrumbLink render={<NavLink href={link.href}>{link.title}</NavLink>} />
-							</BreadcrumbItem>
-						</Fragment>
-					)
-				})}
+				{trailPieces.map(entry => (
+					<Fragment
+						key={entry.kind === "link" ? `${entry.link.href}-${entry.link.title}` : "trail-ellipsis"}
+					>
+						<BreadcrumbSeparator>
+							<Slash />
+						</BreadcrumbSeparator>
+						<BreadcrumbItem>
+							{entry.kind === "link" ? (
+								<BreadcrumbLink render={<NavLink href={entry.link.href}>{entry.link.title}</NavLink>} />
+							) : (
+								<CustomEllipsis menuLinks={menuLinks} />
+							)}
+						</BreadcrumbItem>
+					</Fragment>
+				))}
 			</BreadcrumbList>
 		</Breadcrumb>
 	)

--- a/components/client/breadcrumbs.tsx
+++ b/components/client/breadcrumbs.tsx
@@ -21,7 +21,7 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 
 /** Above this character count on the leaf label, omit the first trail segment on mobile so more fits on one line */
-const LONG_LAST_LABEL_CHARS = 24
+export const LONG_LAST_LABEL_CHARS = 24
 
 export interface Link<T extends string> {
 	href: Route<T>
@@ -30,7 +30,7 @@ export interface Link<T extends string> {
 
 type TrailPiece<T extends string> = { kind: "link"; link: Link<T> } | { kind: "ellipsis" }
 
-/** When `showEllipsis` is true, callers should pass `links.length >= 3`. */
+/** When `showEllipsis` is true, callers normally pass `links.length >= 3`; otherwise returns an empty trail. */
 export function trailAfterHome<T extends string>(
 	links: Link<T>[],
 	showEllipsis: boolean,
@@ -40,6 +40,12 @@ export function trailAfterHome<T extends string>(
 		return links.map(link => ({ kind: "link" as const, link }))
 	}
 
+	if (showEllipsis && links.length < 3) {
+		console.warn("`trailAfterHome` called with `showEllipsis` but `links` has less than 3 items")
+		return []
+	}
+
+	// SAFETY: From this point onwards, `links` has at least 3 items (checked above)
 	const last = links.at(-1)!
 	const head: TrailPiece<T>[] = []
 	if (!collapseAggressive) {

--- a/tests/client/breadcrumbs.test.ts
+++ b/tests/client/breadcrumbs.test.ts
@@ -1,6 +1,6 @@
 import type { Route } from "next"
 import { describe, expect, test } from "vitest"
-import { trailAfterHome, type Link } from "@/components/client/breadcrumbs"
+import { LONG_LAST_LABEL_CHARS, trailAfterHome, type Link } from "@/components/client/breadcrumbs"
 
 function L<const T extends string>(href: T, title: string): Link<T> {
 	return { href: href as Route<T>, title }
@@ -22,6 +22,11 @@ describe("trailAfterHome", () => {
 
 	test("without ellipsis flag, empty links yields empty trail", () => {
 		expect(trailAfterHome([], false, false)).toEqual([])
+	})
+
+	test("with ellipsis flag but no links, yields empty trail (invalid caller contract)", () => {
+		expect(trailAfterHome([], true, false)).toEqual([])
+		expect(trailAfterHome([], true, true)).toEqual([])
 	})
 
 	test("with ellipsis + standard collapse: first segment, single ellipsis, then last (3 links)", () => {
@@ -76,5 +81,57 @@ describe("trailAfterHome", () => {
 		const trail = trailAfterHome(links, true, true)
 		expect(trail).toEqual([{ kind: "ellipsis" }, { kind: "link", link: links[3] }])
 		expect(ellipsisCount(trail)).toBe(1)
+	})
+
+	test("LONG_LAST_LABEL_CHARS boundary: 23-char last title uses standard collapse", () => {
+		const lastTitle = "a".repeat(23)
+		expect(lastTitle.length).toBe(23)
+		const collapseAggressive = lastTitle.length >= LONG_LAST_LABEL_CHARS
+		expect(collapseAggressive).toBe(false)
+
+		const links = [
+			L("/games", "Games"),
+			L("/games/bo6", "BO6"),
+			L("/games/bo6/quest", lastTitle),
+		] as Link<string>[]
+		expect(trailAfterHome(links, true, collapseAggressive)).toEqual([
+			{ kind: "link", link: links[0] },
+			{ kind: "ellipsis" },
+			{ kind: "link", link: links[2] },
+		])
+	})
+
+	test("LONG_LAST_LABEL_CHARS boundary: 24-char last title uses aggressive collapse", () => {
+		const lastTitle = "a".repeat(24)
+		expect(lastTitle.length).toBe(24)
+		const collapseAggressive = lastTitle.length >= LONG_LAST_LABEL_CHARS
+		expect(collapseAggressive).toBe(true)
+
+		const links = [
+			L("/games", "Games"),
+			L("/games/bo6", "BO6"),
+			L("/games/bo6/quest", lastTitle),
+		] as Link<string>[]
+		expect(trailAfterHome(links, true, collapseAggressive)).toEqual([
+			{ kind: "ellipsis" },
+			{ kind: "link", link: links[2] },
+		])
+	})
+
+	test("LONG_LAST_LABEL_CHARS boundary: 25-char last title uses aggressive collapse", () => {
+		const lastTitle = "a".repeat(25)
+		expect(lastTitle.length).toBe(25)
+		const collapseAggressive = lastTitle.length >= LONG_LAST_LABEL_CHARS
+		expect(collapseAggressive).toBe(true)
+
+		const links = [
+			L("/games", "Games"),
+			L("/games/bo6", "BO6"),
+			L("/games/bo6/quest", lastTitle),
+		] as Link<string>[]
+		expect(trailAfterHome(links, true, collapseAggressive)).toEqual([
+			{ kind: "ellipsis" },
+			{ kind: "link", link: links[2] },
+		])
 	})
 })

--- a/tests/client/breadcrumbs.test.ts
+++ b/tests/client/breadcrumbs.test.ts
@@ -1,0 +1,80 @@
+import type { Route } from "next"
+import { describe, expect, test } from "vitest"
+import { trailAfterHome, type Link } from "@/components/client/breadcrumbs"
+
+function L<const T extends string>(href: T, title: string): Link<T> {
+	return { href: href as Route<T>, title }
+}
+
+function ellipsisCount<T extends string>(pieces: ReturnType<typeof trailAfterHome<T>>) {
+	return pieces.filter(p => p.kind === "ellipsis").length
+}
+
+describe("trailAfterHome", () => {
+	test("without ellipsis flag, maps every link in order", () => {
+		const links = [L("/maps", "Maps"), L("/maps/bo6", "BO6")] as Link<string>[]
+		expect(trailAfterHome(links, false, false)).toEqual([
+			{ kind: "link", link: links[0] },
+			{ kind: "link", link: links[1] },
+		])
+		expect(ellipsisCount(trailAfterHome(links, false, false))).toBe(0)
+	})
+
+	test("without ellipsis flag, empty links yields empty trail", () => {
+		expect(trailAfterHome([], false, false)).toEqual([])
+	})
+
+	test("with ellipsis + standard collapse: first segment, single ellipsis, then last (3 links)", () => {
+		const links = [
+			L("/side-quests", "Side Quests"),
+			L("/side-quests/bo6", "BO6"),
+			L("/side-quests/bo6/street", "Street"),
+		] as Link<string>[]
+		const trail = trailAfterHome(links, true, false)
+		expect(trail).toEqual([
+			{ kind: "link", link: links[0] },
+			{ kind: "ellipsis" },
+			{ kind: "link", link: links[2] },
+		])
+		expect(ellipsisCount(trail)).toBe(1)
+	})
+
+	test("with ellipsis + standard collapse: first segment, single ellipsis, then last (4 links)", () => {
+		const links = [
+			L("/a", "A"),
+			L("/a/b", "B"),
+			L("/a/b/c", "C"),
+			L("/a/b/c/d", "D"),
+		] as Link<string>[]
+		const trail = trailAfterHome(links, true, false)
+		expect(trail).toEqual([
+			{ kind: "link", link: links[0] },
+			{ kind: "ellipsis" },
+			{ kind: "link", link: links[3] },
+		])
+		expect(ellipsisCount(trail)).toBe(1)
+	})
+
+	test("with ellipsis + aggressive collapse: only ellipsis then last (3 links)", () => {
+		const links = [
+			L("/relics", "Relics"),
+			L("/relics/bo6", "BO6"),
+			L("/relics/bo6/dead-wire", "Super Long Relic Name Here"),
+		] as Link<string>[]
+		const trail = trailAfterHome(links, true, true)
+		expect(trail).toEqual([{ kind: "ellipsis" }, { kind: "link", link: links[2] }])
+		expect(ellipsisCount(trail)).toBe(1)
+	})
+
+	test("with ellipsis + aggressive collapse: only ellipsis then last (4 links)", () => {
+		const links = [
+			L("/m", "M"),
+			L("/m/a", "A"),
+			L("/m/a/b", "B"),
+			L("/m/a/b/c", "VeryLongFinalSegmentTitle"),
+		] as Link<string>[]
+		const trail = trailAfterHome(links, true, true)
+		expect(trail).toEqual([{ kind: "ellipsis" }, { kind: "link", link: links[3] }])
+		expect(ellipsisCount(trail)).toBe(1)
+	})
+})


### PR DESCRIPTION
Added logic to always collapse when the breadcrumbs contain 3 or more links, while also more aggressively collapsing if the last label is particularly long.  
  
Fixes https://github.com/PlagueFPS/cod-zombies/issues/326