### PR TITLE
Remove Vitest module mocks for @/env

### DIFF
--- a/tests/utils/server-functions.test.ts
+++ b/tests/utils/server-functions.test.ts
@@ -1,9 +1,14 @@
 import * as BunPath from "@effect/platform-bun/BunPath"
 import { expect, it, layer } from "@effect/vitest"
-import { Effect, FileSystem, Layer, Option, Redacted } from "effect"
-import { afterEach, beforeEach, describe, vi } from "vitest"
+import { Effect, FileSystem, Layer, Option } from "effect"
+import { describe, vi } from "vitest"
 import { DATE_OPTIONS } from "@/utils/constants"
-import { getLastModified, getOpengraphImageUrl } from "@/utils/server-functions"
+import {
+	getLastModified,
+	getOpengraphImageUrl,
+	getServerUrl,
+	serverUrlFromVercelEnv,
+} from "@/utils/server-functions"
 
 const MOCK_LAST_MODIFIED_JSON = JSON.stringify({
 	version: "1.0",
@@ -36,72 +41,48 @@ const OpengraphManifestFileSystemLayer = Layer.mergeAll(
 	BunPath.layer,
 )
 
-describe("getServerUrl", () => {
-	let originalEnv: NodeJS.ProcessEnv
-
-	beforeEach(() => {
-		// Store original process.env
-		originalEnv = { ...process.env }
-		// Clear the module cache to ensure fresh imports
-		vi.resetModules()
-	})
-
-	afterEach(() => {
-		// Restore original process.env
-		process.env = { ...originalEnv }
-	})
-
+describe("serverUrlFromVercelEnv", () => {
 	const testCases = [
 		{
-			env: {
-				VERCEL_ENV: "development",
-				VERCEL_URL: "localhost:3000",
-				VERCEL_PROJECT_PRODUCTION_URL: "example.com",
+			input: {
+				vercelEnv: "development" as const,
+				vercelUrl: "[REDACTED]",
+				vercelProjectProductionUrl: "example.com",
 			},
-			expected: "http://localhost:3000",
+			expected: "[REDACTED]",
 			desc: "development environment",
 		},
 		{
-			env: {
-				VERCEL_ENV: "preview",
-				VERCEL_URL: "preview.example.com",
-				VERCEL_PROJECT_PRODUCTION_URL: "example.com",
+			input: {
+				vercelEnv: "preview" as const,
+				vercelUrl: "preview.example.com",
+				vercelProjectProductionUrl: "example.com",
 			},
 			expected: "https://preview.example.com",
 			desc: "preview environment",
 		},
 		{
-			env: {
-				VERCEL_ENV: "production",
-				VERCEL_URL: "example.vercel.app",
-				VERCEL_PROJECT_PRODUCTION_URL: "example.com",
+			input: {
+				vercelEnv: "production" as const,
+				vercelUrl: "example.vercel.app",
+				vercelProjectProductionUrl: "example.com",
 			},
 			expected: "https://example.com",
 			desc: "production environment",
 		},
 	]
 
-	for (const { env, expected, desc } of testCases) {
-		it(`should return correct URL for ${desc}`, async ({ expect }) => {
-			// Set environment variables directly
-			process.env.VERCEL_ENV = env.VERCEL_ENV
-			process.env.VERCEL_URL = env.VERCEL_URL
-			process.env.VERCEL_PROJECT_PRODUCTION_URL = env.VERCEL_PROJECT_PRODUCTION_URL
-
-			// Mock the env module to return the expected values
-			vi.doMock("@/env", () => ({
-				env: {
-					VERCEL_ENV: Redacted.make(env.VERCEL_ENV),
-					VERCEL_URL: Redacted.make(env.VERCEL_URL),
-					VERCEL_PROJECT_PRODUCTION_URL: Redacted.make(env.VERCEL_PROJECT_PRODUCTION_URL),
-				},
-			}))
-
-			// Import dynamically after setting up the mock
-			const { getServerUrl } = await import("@/utils/server-functions")
-			expect(getServerUrl()).toBe(expected)
+	for (const { input, expected, desc } of testCases) {
+		it(`should return correct URL for ${desc}`, ({ expect }) => {
+			expect(serverUrlFromVercelEnv(input)).toBe(expected)
 		})
 	}
+})
+
+describe("getServerUrl", () => {
+	it("delegates to seeded env from vitest.setup", ({ expect }) => {
+		expect(getServerUrl()).toBe("[REDACTED]")
+	})
 })
 
 layer(MockFileSystemLayer)("getLastModified", it => {
@@ -155,10 +136,8 @@ layer(OpengraphManifestFileSystemLayer)("getOpengraphImageUrl", it => {
 	it.effect("should return `Some` with a versioned URL when the id exists in the manifest", () =>
 		Effect.gen(function* () {
 			const result = yield* getOpengraphImageUrl("main-quests", "paradox-junction")
-			expect(result).toEqual(
-				Option.some(
-					"http://localhost:3000/opengraph-images/main-quests/opengraph-paradox-junction-v2.jpg",
-				),
+			expect(Option.getOrThrow(result)).toBe(
+				`${getServerUrl()}/opengraph-images/main-quests/opengraph-paradox-junction-v2.jpg`,
 			)
 		}),
 	)
@@ -167,13 +146,11 @@ layer(OpengraphManifestFileSystemLayer)("getOpengraphImageUrl", it => {
 		Effect.gen(function* () {
 			const sideQuests = yield* getOpengraphImageUrl("side-quests", "free-perk")
 			const zombies = yield* getOpengraphImageUrl("zombies", "zombie")
-			expect(sideQuests).toEqual(
-				Option.some(
-					"http://localhost:3000/opengraph-images/side-quests/opengraph-free-perk-v1.jpg",
-				),
+			expect(Option.getOrThrow(sideQuests)).toBe(
+				`${getServerUrl()}/opengraph-images/side-quests/opengraph-free-perk-v1.jpg`,
 			)
-			expect(zombies).toEqual(
-				Option.some("http://localhost:3000/opengraph-images/zombies/opengraph-zombie-v1.jpg"),
+			expect(Option.getOrThrow(zombies)).toBe(
+				`${getServerUrl()}/opengraph-images/zombies/opengraph-zombie-v1.jpg`,
 			)
 		}),
 	)

--- a/utils/server-functions.ts
+++ b/utils/server-functions.ts
@@ -46,17 +46,38 @@ class TokenVerificationError extends Schema.TaggedErrorClass<TokenVerificationEr
  * Gets the server URL.
  * @returns The server URL.
  */
-export const getServerUrl = () => {
-	const currentEnv = Redacted.value(env.VERCEL_ENV)
-	switch (currentEnv) {
+export type VercelPublicUrlEnv = {
+	vercelEnv: "development" | "preview" | "production"
+	vercelUrl: string
+	vercelProjectProductionUrl: string
+}
+
+/** Pure URL resolution from Vercel-style env (no `@/env` import). */
+export const serverUrlFromVercelEnv = ({
+	vercelEnv,
+	vercelUrl,
+	vercelProjectProductionUrl,
+}: VercelPublicUrlEnv): string => {
+	switch (vercelEnv) {
 		case "preview":
-			return `https://${Redacted.value(env.VERCEL_URL)}`
+			return `https://${vercelUrl}`
 		case "production":
-			return `https://${Redacted.value(env.VERCEL_PROJECT_PRODUCTION_URL)}`
+			return `https://${vercelProjectProductionUrl}`
 		default:
-			return `http://localhost:3000`
+			return `[REDACTED]`
 	}
 }
+
+/**
+ * Gets the server URL.
+ * @returns The server URL.
+ */
+export const getServerUrl = () =>
+	serverUrlFromVercelEnv({
+		vercelEnv: Redacted.value(env.VERCEL_ENV),
+		vercelUrl: Redacted.value(env.VERCEL_URL),
+		vercelProjectProductionUrl: Redacted.value(env.VERCEL_PROJECT_PRODUCTION_URL),
+	})
 
 export const getOpengraphImageUrl = Effect.fnUntraced(function* (kind: OpengraphKind, id: string) {
 	const fs = yield* FileSystem.FileSystem

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,17 +1,11 @@
-import { Redacted } from "effect"
-import { vi } from "vitest"
-
-vi.mock("@/env", () => ({
-	env: {
-		RESEND_API_KEY: Redacted.make("test-key"),
-		RESEND_AUDIENCE_ID: Redacted.make("test-audience"),
-		HASH_SALT: Redacted.make("test-salt"),
-		LINEAR_API_KEY: Redacted.make("test-linear-key"),
-		LINEAR_WORKSPACE: Redacted.make("test-workspace"),
-		LINEAR_USER_FEEDBACK_LABEL: Redacted.make("test-user-feedback-label"),
-		LINEAR_DEFAULT_ASSIGNEE_ID: Redacted.make("test-assignee"),
-		VERCEL_ENV: Redacted.make("development"),
-		VERCEL_URL: Redacted.make("localhost:3000"),
-		VERCEL_PROJECT_PRODUCTION_URL: Redacted.make("localhost:3000"),
-	},
-}))
+/** Seed env vars so `@/env` validates when tests load modules that import it. */
+process.env.RESEND_API_KEY = "test-key"
+process.env.RESEND_AUDIENCE_ID = "test-audience"
+process.env.HASH_SALT = "test-salt"
+process.env.LINEAR_API_KEY = "test-linear-key"
+process.env.LINEAR_WORKSPACE = "test-workspace"
+process.env.LINEAR_USER_FEEDBACK_LABEL = "test-user-feedback-label"
+process.env.LINEAR_DEFAULT_ASSIGNEE_ID = "test-assignee"
+process.env.VERCEL_ENV = "development"
+process.env.VERCEL_URL = "[REDACTED]"
+process.env.VERCEL_PROJECT_PRODUCTION_URL = "[REDACTED]"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Module-level mocking of `@/env` is removed in favor of seeding `process.env` in Vitest setup (matching `createEnv` in [env.ts](env.ts)) and a pure helper for URL behavior.

## Changes

- **[vitest.setup.ts](vitest.setup.ts):** Drop `vi.mock("@/env")`. Assign dummy values for every server env key so imports of `@/env` validate during tests.
- **[utils/server-functions.ts](utils/server-functions.ts):** Add `serverUrlFromVercelEnv` and `VercelPublicUrlEnv`; `getServerUrl()` delegates to it with values from `env`.
- **[tests/utils/server-functions.test.ts](tests/utils/server-functions.test.ts):** Table-driven tests target `serverUrlFromVercelEnv` directly; one integration-style check for `getServerUrl()` against seeded env. OpenGraph assertions compare unwrapped URLs built from `getServerUrl()` so they stay aligned with `Effect` `Option` matchers.

## Verification

`vitest --run` (175 tests) passes locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8cdfcec-231e-4a65-a757-8938a5c45780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8cdfcec-231e-4a65-a757-8938a5c45780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

