### PR TITLE
refactor: improve Carousel UX on all platforms

### DIFF
--- a/components/client/custom-carousel.tsx
+++ b/components/client/custom-carousel.tsx
@@ -1,5 +1,6 @@
 "use client"
 import {
+	Children,
 	useCallback,
 	useEffect,
 	useLayoutEffect,
@@ -7,6 +8,7 @@ import {
 	useState,
 	type CSSProperties,
 } from "react"
+import { Button } from "@/components/ui/button"
 import {
 	Carousel,
 	CarouselContent,
@@ -16,7 +18,6 @@ import {
 	type CarouselApi,
 } from "@/components/ui/carousel"
 import { cn } from "@/lib/utils"
-import { Button } from "`@/components/ui/button`"
 
 interface CustomCarouselProps {
 	children: React.ReactNode
@@ -151,17 +152,11 @@ export default function CustomCarousel({ children, className }: CustomCarouselPr
 	return (
 		<Carousel ref={rootRef} setApi={setApi} className="w-full min-w-0">
 			<CarouselContent className="min-w-0">
-import {
-	Children,
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-	type CSSProperties,
-} from "react"
-} from "react"
-				)}
+				{Children.toArray(children).map((child, index) => (
+					<CarouselItem key={index} className={cn(className)}>
+						{child}
+					</CarouselItem>
+				))}
 			</CarouselContent>
 			<CarouselPrevious
 				variant="secondary"

--- a/components/client/custom-carousel.tsx
+++ b/components/client/custom-carousel.tsx
@@ -16,7 +16,7 @@ import {
 	type CarouselApi,
 } from "@/components/ui/carousel"
 import { cn } from "@/lib/utils"
-import { Button } from "../ui/button"
+import { Button } from "`@/components/ui/button`"
 
 interface CustomCarouselProps {
 	children: React.ReactNode
@@ -151,14 +151,16 @@ export default function CustomCarousel({ children, className }: CustomCarouselPr
 	return (
 		<Carousel ref={rootRef} setApi={setApi} className="w-full min-w-0">
 			<CarouselContent className="min-w-0">
-				{Array.isArray(children) ? (
-					children.map((child, index) => (
-						<CarouselItem key={index} className={cn(className)}>
-							{child}
-						</CarouselItem>
-					))
-				) : (
-					<CarouselItem className={cn(className)}>{children}</CarouselItem>
+import {
+	Children,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	type CSSProperties,
+} from "react"
+} from "react"
 				)}
 			</CarouselContent>
 			<CarouselPrevious

--- a/components/client/custom-carousel.tsx
+++ b/components/client/custom-carousel.tsx
@@ -1,7 +1,12 @@
 "use client"
-
-import type React from "react"
-import { useEffect, useState } from "react"
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	type CSSProperties,
+} from "react"
 import {
 	Carousel,
 	CarouselContent,
@@ -11,16 +16,121 @@ import {
 	type CarouselApi,
 } from "@/components/ui/carousel"
 import { cn } from "@/lib/utils"
+import { Button } from "../ui/button"
 
 interface CustomCarouselProps {
 	children: React.ReactNode
 	className?: string
 }
 
+/** Pixels above the `<img>` bottom edge (inside the image area). */
+const INDICATOR_INSET_FROM_IMAGE_BOTTOM_PX = 12
+/** Ignore bbox reads before layout resolves (FeaturedImage fades in; lazy decode). */
+const MIN_IMG_BOX_FOR_LAYOUT_PX = 4
+
+const INDICATORS_FALLBACK_STYLE: CSSProperties = {
+	left: "50%",
+	bottom: "5rem",
+	transform: "translateX(-50%)",
+}
+
+/** First carousel slide DOM node (Embla `slideNodes()` or first `[data-slot="carousel-item"]`). */
+function firstSlideEl(root: HTMLElement, api: CarouselApi | undefined): HTMLElement | null {
+	const n = api?.slideNodes()[0]
+	if (n instanceof HTMLElement) return n
+	const q = root.querySelector('[data-slot="carousel-item"]')
+	return q instanceof HTMLElement ? q : null
+}
+
+function firstSlideImg(
+	root: HTMLElement,
+	api: CarouselApi | undefined,
+): HTMLImageElement | undefined {
+	return firstSlideEl(root, api)?.querySelector("img") ?? undefined
+}
+
 export default function CustomCarousel({ children, className }: CustomCarouselProps) {
+	const rootRef = useRef<HTMLDivElement>(null)
+	const dotsPositionLockedRef = useRef(false)
+	/**
+	 * This ref avoids listing `api` on `tryLockDotsPosition` deps so its identity
+	 * stays stable while reads still see the live API.
+	 */
+	const apiRef = useRef<CarouselApi | undefined>(undefined)
+
 	const [api, setApi] = useState<CarouselApi>()
 	const [currentIndex, setCurrentIndex] = useState(0)
 	const [count, setCount] = useState(0)
+	const [indicatorStyle, setIndicatorStyle] = useState<CSSProperties>(INDICATORS_FALLBACK_STYLE)
+
+	apiRef.current = api
+
+	const tryLockDotsPosition = useCallback(() => {
+		if (dotsPositionLockedRef.current) return
+
+		const root = rootRef.current
+		if (!root || count <= 1) return
+
+		const img = firstSlideImg(root, apiRef.current)
+
+		if (img == null) {
+			dotsPositionLockedRef.current = true
+			setIndicatorStyle(INDICATORS_FALLBACK_STYLE)
+			return
+		}
+
+		const rootRect = root.getBoundingClientRect()
+		const imgRect = img.getBoundingClientRect()
+
+		if (imgRect.height < MIN_IMG_BOX_FOR_LAYOUT_PX || imgRect.width < MIN_IMG_BOX_FOR_LAYOUT_PX) {
+			if (img.complete) {
+				dotsPositionLockedRef.current = true
+				setIndicatorStyle(INDICATORS_FALLBACK_STYLE)
+			}
+			return
+		}
+
+		dotsPositionLockedRef.current = true
+		setIndicatorStyle({
+			left: "50%",
+			bottom: rootRect.bottom - imgRect.bottom + INDICATOR_INSET_FROM_IMAGE_BOTTOM_PX,
+			transform: "translateX(-50%)",
+		})
+	}, [count])
+
+	useLayoutEffect(() => {
+		if (count <= 1) return
+		tryLockDotsPosition()
+	}, [count, tryLockDotsPosition])
+
+	useEffect(() => {
+		if (count <= 1 || dotsPositionLockedRef.current) return
+
+		const root = rootRef.current
+		if (!root) return
+
+		const img = firstSlideImg(root, apiRef.current)
+		if (!img) {
+			tryLockDotsPosition()
+			return
+		}
+
+		const onReady = () => tryLockDotsPosition()
+
+		img.addEventListener("load", onReady, { once: true })
+
+		let decodeCancelled = false
+		void (img.decode?.() ?? Promise.resolve())
+			.catch(() => {})
+			.then(() => {
+				if (!decodeCancelled && img.isConnected) tryLockDotsPosition()
+			})
+
+		return () => {
+			decodeCancelled = true
+			img.removeEventListener("load", onReady)
+		}
+	}, [api, count, tryLockDotsPosition])
 
 	useEffect(() => {
 		if (!api) return
@@ -39,34 +149,41 @@ export default function CustomCarousel({ children, className }: CustomCarouselPr
 	}, [api])
 
 	return (
-		<>
-			<Carousel setApi={setApi}>
-				<CarouselContent>
-					{Array.isArray(children) ? (
-						children.map((child, index) => (
-							<CarouselItem key={index} className={cn(className)}>
-								{child}
-							</CarouselItem>
-						))
-					) : (
-						<CarouselItem className={cn(className)}>{children}</CarouselItem>
-					)}
-				</CarouselContent>
-				<CarouselPrevious variant="secondary" className="hidden sm:flex" />
-				<CarouselNext variant="secondary" className="hidden sm:flex" />
-			</Carousel>
+		<Carousel ref={rootRef} setApi={setApi} className="w-full min-w-0">
+			<CarouselContent className="min-w-0">
+				{Array.isArray(children) ? (
+					children.map((child, index) => (
+						<CarouselItem key={index} className={cn(className)}>
+							{child}
+						</CarouselItem>
+					))
+				) : (
+					<CarouselItem className={cn(className)}>{children}</CarouselItem>
+				)}
+			</CarouselContent>
+			<CarouselPrevious
+				variant="secondary"
+				size="icon"
+				className="absolute left-2 flex md:left-4"
+			/>
+			<CarouselNext variant="secondary" size="icon" className="absolute right-5 flex md:right-4" />
 			{count > 1 ? (
-				<div className="flex justify-center gap-1.5" role="tablist" aria-label="Carousel slides">
+				<div
+					style={indicatorStyle}
+					className="pointer-events-auto absolute z-10 inline-flex w-fit items-center justify-center gap-1 rounded-full border border-input/30 bg-black/65 px-2 py-1.5 shadow-lg backdrop-blur-md supports-[backdrop-filter]:bg-black/45 dark:border-input"
+					role="tablist"
+					aria-label="Carousel slides"
+				>
 					{Array.from({ length: count }, (_, i) => (
-						<button
+						<Button
 							key={i}
-							type="button"
+							size="icon-xs"
 							aria-current={i === currentIndex}
 							aria-label={`Slide ${i + 1} of ${count}`}
 							className={cn(
-								"h-1.5 w-1.5 shrink-0 rounded-full transition-[background-color,transform] duration-200",
+								"h-2 w-2 shrink-0 rounded-full transition-[background-color,transform] duration-200 md:h-2.5 md:w-2.5",
 								i === currentIndex
-									? "scale-110 bg-muted-foreground"
+									? "scale-110 bg-primary"
 									: "bg-muted-foreground/35 hover:bg-muted-foreground/55",
 							)}
 							onClick={() => api?.scrollTo(i)}
@@ -74,6 +191,6 @@ export default function CustomCarousel({ children, className }: CustomCarouselPr
 					))}
 				</div>
 			) : null}
-		</>
+		</Carousel>
 	)
 }


### PR DESCRIPTION
Dynamically calculates the height of the given carousel instance to ensure proper positioning of the slide indicators, regardless of caption length. Also always shows the prev/next buttons within the image to improve mobile accessibility and retain the visual indicator that there are more images to view.

Closes https://github.com/PlagueFPS/cod-zombies/issues/336