### PR TITLE
update: increase RichImage resolution for better visual fidelity

### DIFF
--- a/components/client/quest-preview-card.tsx
+++ b/components/client/quest-preview-card.tsx
@@ -146,7 +146,7 @@ export function QuestPreviewCard({ quest, questIndex }: IQuestPreviewCard) {
 							featuredImage={image}
 							width={272}
 							height={176}
-							sizes="272px"
+							sizes="384px"
 							className="aspect-square scale-150"
 						/>
 					</div>
@@ -158,7 +158,7 @@ export function QuestPreviewCard({ quest, questIndex }: IQuestPreviewCard) {
 								priority={priority}
 								width={272}
 								height={176}
-								sizes="272px"
+								sizes="384px"
 								className="h-44 rounded-md object-cover"
 							/>
 						</div>

--- a/components/client/rich-image.tsx
+++ b/components/client/rich-image.tsx
@@ -22,8 +22,7 @@ interface RichImageProps {
 export default function RichImage({ image, caption, alt }: RichImageProps) {
 	const imageProps: ImageProps = {
 		featuredImage: image,
-		// Force all content images to be rendered at the highest allowed resolution
-		sizes: "1920px",
+		sizes: "(max-width: 828px) 100vw, 1200px",
 	}
 
 	return (
@@ -51,6 +50,7 @@ export default function RichImage({ image, caption, alt }: RichImageProps) {
 							width={1920}
 							height={1080}
 							alt={alt ?? ""}
+							sizes="(max-width: 1920px) 100vw, 1920px"
 							className="cursor-zoom-out rounded-lg"
 						/>
 					</DialogClose>

--- a/components/client/rich-image.tsx
+++ b/components/client/rich-image.tsx
@@ -22,7 +22,8 @@ interface RichImageProps {
 export default function RichImage({ image, caption, alt }: RichImageProps) {
 	const imageProps: ImageProps = {
 		featuredImage: image,
-		sizes: "(max-width: 828px) calc(100vw - 16px), 776px",
+		// Force all content images to be rendered at the highest allowed resolution
+		sizes: "1920px",
 	}
 
 	return (
@@ -50,7 +51,6 @@ export default function RichImage({ image, caption, alt }: RichImageProps) {
 							width={1920}
 							height={1080}
 							alt={alt ?? ""}
-							sizes="(max-width: 1920px) calc(100vw - 16px), 1920px"
 							className="cursor-zoom-out rounded-lg"
 						/>
 					</DialogClose>


### PR DESCRIPTION
Hints to the browser to render all content images at 1200w on screens larger than 828w as a base (high density retina displays still can cause larger images to be rendered), which greatly increases visual fidelity when the rendered size is at most 828w. We eat slightly more bandwidth on desktop, with no change on most mobile devices due to their pixel density, and potentially negatively affect lighthouse scores, but for much better image quality for our most important images on screens larger than 828w, and the practical performance should remain unchanged based on how images are loaded.

Even with this change, our largest image on the entire site is only 119KB, which is a 75% increase from 68KB before this change. However the true max remains unchanged at 300KB for the largest image on the site rendered at 1920px, which would be the case for any high retina desktop displays (like 4K monitors). Meaning this change just improves the visual quality for the most common desktop displays, while the high-end remains unchanged.