### PR TITLE
feat: enable Workers cache

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,7 @@
 	"compatibility_flags": ["nodejs_compat"],
 	"main": "@tanstack/react-start/server-entry",
 	"preview_urls": true,
+	"cache": { "enabled": true },
 	"vars": {
 		"GITHUB_REPO_OWNER": "PlagueFPS",
 		"GITHUB_REPO_NAME": "cod-zombies",


### PR DESCRIPTION
Enables the newly released Workers Cache feature on Cloudflare to allow for HTTP caching in front of workers to completely prevent uneccessary invocation