### PR TITLE
update: remove New status from content

### DIFF
--- a/src/data/interactive-map.ts
+++ b/src/data/interactive-map.ts
@@ -97,7 +97,7 @@ const makeMapEntry = <T extends string>(
 const INTERACTIVE_MAPS = new Map([
 	makeMapEntry("kowakujo", {
 		title: "Kowakujō",
-		state: Option.some("New"),
+		state: Option.none(),
 		image: "/previews/kowakujo-preview.webp",
 		game: "black-ops-7",
 		description:

--- a/src/data/maps.ts
+++ b/src/data/maps.ts
@@ -842,7 +842,7 @@ const MAPS = new Map([
 			"On the fractured slopes of a volcanic landscape, a castle harbors a smoldering mystery. Face the Dragon's undead army, investigate the Shogun's fate, and expose the curse that blackened Takeo's soul.",
 		image: "/maps/kowakujo.webp",
 		game: "black-ops-7",
-		state: Option.some("New"),
+		state: Option.none(),
 		mainQuest: Option.some("content/main-quests/kowakujo"),
 		difficulty: Option.some("Hard"),
 		estimatedTimeMins: Option.some({

--- a/src/data/relics.ts
+++ b/src/data/relics.ts
@@ -461,7 +461,7 @@ const RELICS = new Map([
 	}),
 	makeRelic("gramophone", {
 		title: "Gramophone",
-		state: Option.some("New"),
+		state: Option.none(),
 		type: "Grim",
 		image: "/relics/gramophone-relic-v1.webp",
 		description: "Bullets deal increased damage but each shot consumes 2 bullets.",
@@ -476,7 +476,7 @@ const RELICS = new Map([
 	}),
 	makeRelic("film-reel", {
 		title: "Film Reel",
-		state: Option.some("New"),
+		state: Option.none(),
 		type: "Sinister",
 		image: "/relics/film-reel-relic-v1.webp",
 		description: "Player can only carry one Pack-a-Punch weapon.",
@@ -491,7 +491,7 @@ const RELICS = new Map([
 	}),
 	makeRelic("mannequin-turret", {
 		title: "Mannequin Turret",
-		state: Option.some("New"),
+		state: Option.none(),
 		type: "Wicked",
 		image: "/relics/mannequin-turret-relic-v1.webp",
 		description: "No starting Armor. Only armor available is gold armor from the wall buy.",
@@ -506,7 +506,7 @@ const RELICS = new Map([
 	}),
 	makeRelic("dragon-egg", {
 		title: "Dragon Egg",
-		state: Option.some("New"),
+		state: Option.none(),
 		type: "Wicked",
 		image: "/relics/dragon-egg-relic-v1.webp",
 		description: "Elites and Special zombies in normal round spawning will now be randomized.",
@@ -521,7 +521,7 @@ const RELICS = new Map([
 	}),
 	makeRelic("valkyrie-helmet", {
 		title: "Valkyrie Helmet",
-		state: Option.some("New"),
+		state: Option.none(),
 		type: "Sinister",
 		image: "/relics/valkyrie-helmet-relic-v1.webp",
 		description: "Areas you stay in start to spawn electric fields that damage you.",
@@ -536,7 +536,7 @@ const RELICS = new Map([
 	}),
 	makeRelic("druid-stone", {
 		title: "Druid Stone",
-		state: Option.some("New"),
+		state: Option.none(),
 		type: "Grim",
 		image: "/relics/druid-stone-relic.webp",
 		description: "No bleed out bar self-revives instantly revives you",

--- a/src/data/side-quests.ts
+++ b/src/data/side-quests.ts
@@ -1677,7 +1677,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/richtofen-jumpscare",
 	}),
 	makeQuest("the-reunion", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "The Reunion",
 		description:
 			"Confront Takeo's past in this cinematic story-driven experience revealing hidden mysterious about this character.",
@@ -1685,7 +1685,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/the-reunion",
 	}),
 	makeQuest("maneka-mecha", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Maneka Mecha",
 		description:
 			"Rebuild and destroy a familiar enemy and gain access to one of the most powerful innovations of human engineering.",
@@ -1693,7 +1693,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/maneka-mecha",
 	}),
 	makeQuest("path-of-sorrows", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Path of Sorrows",
 		description:
 			"Learn how to obtain Takeo Masaki's legendary katana by perfectly solving his father's murder.",
@@ -1701,7 +1701,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/path-of-sorrows",
 	}),
 	makeQuest("neko-cafe", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Neko Cafe",
 		description:
 			"Find and gather all the stray cats in the castle to open your very own Neko Cafe and obtain some useful rewards.",
@@ -1709,7 +1709,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/neko-cafe",
 	}),
 	makeQuest("maneki-bomb", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Maneki-Bomb",
 		description:
 			"Learn how to upgraded the map specific tactical to increase its effectiveness and usability.",
@@ -1717,7 +1717,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/maneki-bomb",
 	}),
 	makeQuest("evencry", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Evencry",
 		description:
 			'Discover how to activate the hidden music easter egg song "Evencry" by Kevin Sherwood.',
@@ -1725,7 +1725,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/evencry",
 	}),
 	makeQuest("horse-race", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Horse Race",
 		description:
 			"Race against the clock to earn powerful rewards, including a secret reward if you're really fast.",
@@ -1733,7 +1733,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/horse-race",
 	}),
 	makeQuest("ghostly-rifleman-upgrade", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Ghostly Rifleman Upgrade",
 		description:
 			"Learn how to upgrade the Ghostly Rifleman traps up to four total times to make them incredibly effective and useful.",
@@ -1741,7 +1741,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/ghostly-rifleman-upgrade",
 	}),
 	makeQuest("hidden-power-ups-kowakujo", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Hidden Power-Ups",
 		description:
 			"Discover the location of every hidden Power-Up drop in Kowakujō, in case you need them.",
@@ -1749,7 +1749,7 @@ const SIDE_QUESTS = new Map([
 		content: "content/side-quests/hidden-power-ups-kowakujo",
 	}),
 	makeQuest("par-course", {
-		state: Option.some("New"),
+		state: Option.none(),
 		title: "Par Course",
 		description:
 			"Complete this fiery parkour course on the map to receive a familiar weapon in a familiar way of the past.",

--- a/src/data/zombies.ts
+++ b/src/data/zombies.ts
@@ -1807,7 +1807,7 @@ const ZOMBIES = new Map([
 	}),
 	makeZombie("frost-zombie", {
 		title: "Frost Zombie",
-		state: Option.some("New"),
+		state: Option.none(),
 		releaseDate: "2026-04-30",
 		image: "/zombies/frost-zombie.webp",
 		description:
@@ -1825,7 +1825,7 @@ const ZOMBIES = new Map([
 	}),
 	makeZombie("necropincer", {
 		title: "Necropincer",
-		state: Option.some("New"),
+		state: Option.none(),
 		releaseDate: "2026-04-30",
 		image: "/zombies/necropincer.webp",
 		description:
@@ -1843,7 +1843,7 @@ const ZOMBIES = new Map([
 	}),
 	makeZombie("dravakar", {
 		title: "Dravakar",
-		state: Option.some("New"),
+		state: Option.none(),
 		releaseDate: "2026-04-30",
 		image: "/zombies/dravakar.webp",
 		description:
@@ -1861,7 +1861,7 @@ const ZOMBIES = new Map([
 	}),
 	makeZombie("gjallarfrost", {
 		title: "Gjallarfrost",
-		state: Option.some("New"),
+		state: Option.none(),
 		releaseDate: "2026-04-30",
 		image: "/zombies/gjallarfrost.webp",
 		description:
@@ -1879,7 +1879,7 @@ const ZOMBIES = new Map([
 	}),
 	makeZombie("scorched-zombie", {
 		title: "Scorched Zombie",
-		state: Option.some("New"),
+		state: Option.none(),
 		releaseDate: "2026-06-25",
 		image: "/zombies/scorched-zombie.webp",
 		description:
@@ -1897,7 +1897,7 @@ const ZOMBIES = new Map([
 	}),
 	makeZombie("oni", {
 		title: "Oni",
-		state: Option.some("New"),
+		state: Option.none(),
 		releaseDate: "2026-06-25",
 		image: "/zombies/oni.webp",
 		description:
@@ -1915,7 +1915,7 @@ const ZOMBIES = new Map([
 	}),
 	makeZombie("nxyara", {
 		title: "Nxyara",
-		state: Option.some("New"),
+		state: Option.none(),
 		releaseDate: "2026-06-25",
 		image: "/zombies/nyxara.webp",
 		description:

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -44,9 +44,6 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 			{
 				src: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2572200153117332",
 			},
-			{
-				src: "https://www.googletagmanager.com/gtag/js?id=G-2M6PMT6Z3R",
-			},
 		],
 	}),
 	shellComponent: RootLayout,

--- a/src/routes/robots[.]txt.ts
+++ b/src/routes/robots[.]txt.ts
@@ -9,7 +9,9 @@ export const Route = createFileRoute("/robots.txt")({
 				const robots = `
 User-agent: *
 Allow: /
+Allow: /cdn-cgi/image/
 Disallow: /newsletter/**
+Disallow: /cdn-cgi/
 
 Sitemap: ${serverUrl}/sitemap.xml
 				`

--- a/tests/data/zombies.test.ts
+++ b/tests/data/zombies.test.ts
@@ -1,7 +1,26 @@
+import type { ContentState } from "@/types/data"
 import { Option, Array as Arr } from "effect"
-import { afterEach, describe, expect, test, vi } from "vitest"
-import { getAdjacentZombies, getZombieByKey, getZombies, type ZombieKey } from "@/data/zombies"
+import { describe, expect, test } from "vitest"
+import {
+	getAdjacentZombies,
+	getZombieByKey,
+	getZombies,
+	type Zombie,
+	type ZombieKey,
+} from "@/data/zombies"
 import { assertSortedDescByDate } from "@/tests/helpers"
+import { resolveNewContentState } from "@/utils/content-state"
+
+/** Minimal catalog-shaped fixture for `"New"` resolution (does not depend on real ZOMBIES rows). */
+const zombieNewBadgeFixture = (releaseDate: string): Pick<Zombie, "releaseDate" | "state"> => ({
+	releaseDate,
+	state: Option.some("New"),
+})
+
+const resolvedZombieDisplayState = (
+	fixture: Pick<Zombie, "releaseDate" | "state">,
+	isoUtcInstant: string,
+) => resolveNewContentState(fixture.state, fixture.releaseDate, Date.parse(isoUtcInstant))
 
 describe("getZombies", () => {
 	test("sorted by release date descending", () => {
@@ -24,37 +43,48 @@ describe("getZombieByKey", () => {
 	})
 })
 
-describe("zombie New badge vs release date", () => {
-	afterEach(() => {
-		vi.useRealTimers()
-	})
+describe("zombie New badge vs release date (fixtures)", () => {
+	const fixture = zombieNewBadgeFixture("2026-04-30")
 
 	test("drops New when release date is 14+ full calendar days in the past", () => {
-		vi.useFakeTimers()
-		vi.setSystemTime(new Date("2026-05-15T12:00:00.000Z"))
-		const dravakar = getZombieByKey("dravakar").pipe(Option.getOrThrow)
-		expect(Option.getOrNull(dravakar.state)).toBeNull()
+		expect(
+			Option.getOrNull(resolvedZombieDisplayState(fixture, "2026-05-15T12:00:00.000Z")),
+		).toBeNull()
 	})
 
 	test("keeps New within 14 days of release date", () => {
-		vi.useFakeTimers()
-		vi.setSystemTime(new Date("2026-05-10T12:00:00.000Z"))
-		const dravakar = getZombieByKey("dravakar").pipe(Option.getOrThrow)
-		expect(Option.getOrNull(dravakar.state)).toBe("New")
+		expect(Option.getOrNull(resolvedZombieDisplayState(fixture, "2026-05-10T12:00:00.000Z"))).toBe(
+			"New",
+		)
 	})
 
 	test("keeps New through the last instant before the 14th full UTC day after release", () => {
-		vi.useFakeTimers()
-		vi.setSystemTime(new Date("2026-05-13T23:59:59.999Z"))
-		const dravakar = getZombieByKey("dravakar").pipe(Option.getOrThrow)
-		expect(Option.getOrNull(dravakar.state)).toBe("New")
+		expect(Option.getOrNull(resolvedZombieDisplayState(fixture, "2026-05-13T23:59:59.999Z"))).toBe(
+			"New",
+		)
 	})
 
 	test("drops New at the start of the 14th full UTC day after release", () => {
-		vi.useFakeTimers()
-		vi.setSystemTime(new Date("2026-05-14T00:00:00.000Z"))
-		const dravakar = getZombieByKey("dravakar").pipe(Option.getOrThrow)
-		expect(Option.getOrNull(dravakar.state)).toBeNull()
+		expect(
+			Option.getOrNull(resolvedZombieDisplayState(fixture, "2026-05-14T00:00:00.000Z")),
+		).toBeNull()
+	})
+
+	test("stored None stays None regardless of calendar age", () => {
+		const noBadge: Pick<Zombie, "releaseDate" | "state"> = {
+			...fixture,
+			state: Option.none<ContentState>(),
+		}
+		expect(
+			Option.getOrNull(resolvedZombieDisplayState(noBadge, "2026-05-10T12:00:00.000Z")),
+		).toBeNull()
+	})
+
+	test('stored Coming Soon is preserved when stored state is Some("Coming Soon")', () => {
+		const comingSoon = { ...fixture, state: Option.some("Coming Soon" as const) }
+		expect(
+			Option.getOrNull(resolvedZombieDisplayState(comingSoon, "2026-05-15T12:00:00.000Z")),
+		).toBe("Coming Soon")
 	})
 })
 


### PR DESCRIPTION
Removes the "New" status from all Kowakujo and Totenreich content that still had it in the data model.