### PR TITLE
fix: backwards-compatible search param parsing for repeated query keys

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "@/contexts/theme-provider"
 import { MDX_COMPONENT_QUERY_KEY } from "@/data/queries"
 import { routeTree } from "@/routeTree.gen"
 import { getServerUrl } from "@/utils/request"
+import { parseSearch } from "@/utils/search-params"
 
 /**
  * Removes keys from a search object that would serialize to noise in the URL.
@@ -51,6 +52,7 @@ export function getRouter() {
 		defaultErrorComponent: DefaultError,
 		defaultNotFoundComponent: DefaultNotFound,
 		defaultPreload: "intent",
+		parseSearch,
 		stringifySearch,
 		context: {
 			serverUrl,

--- a/src/utils/search-params.ts
+++ b/src/utils/search-params.ts
@@ -1,50 +1,38 @@
 import { parseSearchWith } from "@tanstack/react-router"
-import { Schema, SchemaGetter } from "effect"
 
 const jsonParseSearch = parseSearchWith(JSON.parse)
 
-function parseJsonScalarString(value: string): string {
-	try {
-		const parsed: unknown = JSON.parse(value)
-		if (typeof parsed === "string" || typeof parsed === "number" || typeof parsed === "boolean") {
-			return String(parsed)
+function normalizeSearchElement(value: unknown): unknown {
+	if (typeof value === "string") {
+		try {
+			const parsed: unknown = JSON.parse(value)
+			if (typeof parsed === "string" || typeof parsed === "number" || typeof parsed === "boolean") {
+				return String(parsed)
+			}
+		} catch {
+			// Plain string values are valid filter params.
 		}
-	} catch {
-		// Plain string values are valid filter params.
+		return value
 	}
+
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value)
+	}
+
 	return value
 }
 
-const SearchParamElementSchema = Schema.Union([
-	Schema.String.pipe(
-		Schema.decode({
-			decode: SchemaGetter.transform(parseJsonScalarString),
-			encode: SchemaGetter.passthrough(),
-		}),
-	),
-	Schema.Number.pipe(
-		Schema.decodeTo(Schema.String, {
-			decode: SchemaGetter.transform(String),
-			encode: SchemaGetter.transform(Number),
-		}),
-	),
-	Schema.Boolean.pipe(
-		Schema.decodeTo(Schema.String, {
-			decode: SchemaGetter.transform(String),
-			encode: SchemaGetter.transform(value => value === "true"),
-		}),
-	),
-	Schema.Unknown,
-])
+function normalizeSearchValue(value: unknown): unknown {
+	if (value === undefined || value === null) {
+		return value
+	}
 
-const SearchParamValueSchema = Schema.Union([
-	Schema.Null,
-	Schema.Undefined,
-	Schema.Array(SearchParamElementSchema),
-	SearchParamElementSchema,
-])
+	if (Array.isArray(value)) {
+		return value.map(element => normalizeSearchElement(element))
+	}
 
-const decodeSearchParamValue = Schema.decodeUnknownSync(SearchParamValueSchema)
+	return normalizeSearchElement(value)
+}
 
 /**
  * Normalizes TanStack Router's parsed query object so multi-value search params
@@ -59,7 +47,7 @@ export function normalizeParsedSearch(search: Record<string, unknown>): Record<s
 	const out: Record<string, unknown> = {}
 
 	for (const key in search) {
-		out[key] = decodeSearchParamValue(search[key])
+		out[key] = normalizeSearchValue(search[key])
 	}
 
 	return out

--- a/src/utils/search-params.ts
+++ b/src/utils/search-params.ts
@@ -1,38 +1,50 @@
 import { parseSearchWith } from "@tanstack/react-router"
+import { Schema, SchemaGetter } from "effect"
 
 const jsonParseSearch = parseSearchWith(JSON.parse)
 
-function normalizeSearchElement(value: unknown): unknown {
-	if (typeof value === "string") {
-		try {
-			const parsed: unknown = JSON.parse(value)
-			if (typeof parsed === "string" || typeof parsed === "number" || typeof parsed === "boolean") {
-				return String(parsed)
-			}
-		} catch {
-			// Plain string values are valid filter params.
+function parseJsonScalarString(value: string): string {
+	try {
+		const parsed: unknown = JSON.parse(value)
+		if (typeof parsed === "string" || typeof parsed === "number" || typeof parsed === "boolean") {
+			return String(parsed)
 		}
-		return value
+	} catch {
+		// Plain string values are valid filter params.
 	}
-
-	if (typeof value === "number" || typeof value === "boolean") {
-		return String(value)
-	}
-
 	return value
 }
 
-function normalizeSearchValue(value: unknown): unknown {
-	if (value === undefined || value === null) {
-		return value
-	}
+const SearchParamElementSchema = Schema.Union([
+	Schema.String.pipe(
+		Schema.decode({
+			decode: SchemaGetter.transform(parseJsonScalarString),
+			encode: SchemaGetter.passthrough(),
+		}),
+	),
+	Schema.Number.pipe(
+		Schema.decodeTo(Schema.String, {
+			decode: SchemaGetter.transform(String),
+			encode: SchemaGetter.transform(Number),
+		}),
+	),
+	Schema.Boolean.pipe(
+		Schema.decodeTo(Schema.String, {
+			decode: SchemaGetter.transform(String),
+			encode: SchemaGetter.transform(value => value === "true"),
+		}),
+	),
+	Schema.Unknown,
+])
 
-	if (Array.isArray(value)) {
-		return value.map(element => normalizeSearchElement(element))
-	}
+const SearchParamValueSchema = Schema.Union([
+	Schema.Null,
+	Schema.Undefined,
+	Schema.Array(SearchParamElementSchema),
+	SearchParamElementSchema,
+])
 
-	return normalizeSearchElement(value)
-}
+const decodeSearchParamValue = Schema.decodeUnknownSync(SearchParamValueSchema)
 
 /**
  * Normalizes TanStack Router's parsed query object so multi-value search params
@@ -47,7 +59,7 @@ export function normalizeParsedSearch(search: Record<string, unknown>): Record<s
 	const out: Record<string, unknown> = {}
 
 	for (const key in search) {
-		out[key] = normalizeSearchValue(search[key])
+		out[key] = decodeSearchParamValue(search[key])
 	}
 
 	return out

--- a/src/utils/search-params.ts
+++ b/src/utils/search-params.ts
@@ -1,0 +1,58 @@
+import { parseSearchWith } from "@tanstack/react-router"
+
+const jsonParseSearch = parseSearchWith(JSON.parse)
+
+function normalizeSearchElement(value: unknown): unknown {
+	if (typeof value === "string") {
+		try {
+			const parsed: unknown = JSON.parse(value)
+			if (typeof parsed === "string" || typeof parsed === "number" || typeof parsed === "boolean") {
+				return String(parsed)
+			}
+		} catch {
+			// Plain string values are valid filter params.
+		}
+		return value
+	}
+
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value)
+	}
+
+	return value
+}
+
+function normalizeSearchValue(value: unknown): unknown {
+	if (value === undefined || value === null) {
+		return value
+	}
+
+	if (Array.isArray(value)) {
+		return value.map(element => normalizeSearchElement(element))
+	}
+
+	return normalizeSearchElement(value)
+}
+
+/**
+ * Normalizes TanStack Router's parsed query object so multi-value search params
+ * decode consistently regardless of URL encoding style.
+ *
+ * Supports:
+ * - JSON arrays: `?game=["a","b"]`
+ * - Repeated keys: `?game=a&game=b`
+ * - Single values: `?game=a`
+ */
+export function normalizeParsedSearch(search: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {}
+
+	for (const key in search) {
+		out[key] = normalizeSearchValue(search[key])
+	}
+
+	return out
+}
+
+export function parseSearch(searchStr: string): Record<string, unknown> {
+	return normalizeParsedSearch(jsonParseSearch(searchStr))
+}

--- a/tests/e2e/curated-journeys.spec.ts
+++ b/tests/e2e/curated-journeys.spec.ts
@@ -11,6 +11,15 @@ test.describe("curated listing journeys", () => {
 		await expect(page.getByRole("link", { name: /View Guide for/ }).first()).toBeVisible()
 	})
 
+	test("filters main quests from repeated non-json query keys", async ({ page }) => {
+		await page.goto("/main-quests/?game=black-ops-1&game=black-ops-2")
+
+		await expect(page.getByRole("heading", { name: "Main Quests" })).toBeVisible()
+		await expect(page.getByLabel("Black Ops 1")).toBeVisible()
+		await expect(page.getByLabel("Black Ops 2")).toBeVisible()
+		await expect(page.getByRole("link", { name: /View Guide for/ })).toHaveCount(9)
+	})
+
 	test("filters relics through one representative type", async ({ page }) => {
 		await page.goto("/relics/?type=%5B%22grim%22%5D&sort=%22type-asc%22")
 

--- a/tests/utils/search-params.test.ts
+++ b/tests/utils/search-params.test.ts
@@ -1,0 +1,93 @@
+import { stringifySearchWith } from "@tanstack/react-router"
+import { describe, expect, test } from "vitest"
+import { getMapsWithMainQuest, type MapEntry } from "@/data/maps"
+import { expectExitSuccess } from "@/tests/helpers"
+import { applyFilters, type FilterSpec } from "@/utils/filter-helpers"
+import { normalizeParsedSearch, parseSearch } from "@/utils/search-params"
+import { decodeMainQuestSearchParams } from "@/utils/validation-schemas"
+
+const baseStringifySearch = stringifySearchWith(JSON.stringify, JSON.parse)
+
+function pruneEmptySearch(search: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {}
+	for (const key in search) {
+		const value = search[key]
+		if (value === undefined || value === null) continue
+		if (Array.isArray(value) && value.length === 0) continue
+		out[key] = value
+	}
+	return out
+}
+
+const stringifySearch = (search: Record<string, unknown>) =>
+	baseStringifySearch(pruneEmptySearch(search))
+
+describe("parseSearch", () => {
+	test("decodes repeated query keys into string arrays", () => {
+		expect(parseSearch("game=black-ops-1&game=black-ops-2")).toEqual({
+			game: ["black-ops-1", "black-ops-2"],
+		})
+	})
+
+	test("decodes json-encoded multi-value params", () => {
+		expect(parseSearch("game=%5B%22black-ops-1%22%2C%22black-ops-2%22%5D")).toEqual({
+			game: ["black-ops-1", "black-ops-2"],
+		})
+	})
+
+	test("coerces single plain values to arrays through validation", () => {
+		const parsed = parseSearch("game=black-ops-1")
+		const validated = expectExitSuccess(decodeMainQuestSearchParams(parsed))
+		expect(validated.game).toEqual(["black-ops-1"])
+	})
+
+	test("coerces repeated numeric-looking values to strings", () => {
+		expect(parseSearch("game=0&game=1")).toEqual({
+			game: ["0", "1"],
+		})
+	})
+
+	test("round-trips repeated keys through stringifySearch", () => {
+		const parsed = parseSearch("game=black-ops-1&game=black-ops-2&sort=oldest")
+		const searchStr = stringifySearch(parsed)
+		const reparsed = parseSearch(searchStr.replace(/^\?/, ""))
+
+		expect(reparsed).toEqual({
+			game: ["black-ops-1", "black-ops-2"],
+			sort: "oldest",
+		})
+	})
+})
+
+describe("normalizeParsedSearch", () => {
+	test("normalizes repeated keys that were coerced to numbers", () => {
+		expect(
+			normalizeParsedSearch({
+				game: [0, 1],
+			}),
+		).toEqual({
+			game: ["0", "1"],
+		})
+	})
+})
+
+describe("main quest filter integration", () => {
+	test("filters maps from both games when using repeated query keys", () => {
+		const parsed = parseSearch("game=black-ops-1&game=black-ops-2")
+		const validated = expectExitSuccess(decodeMainQuestSearchParams(parsed))
+
+		const filterSpecs: FilterSpec<MapEntry>[] = [
+			{
+				values: validated.game,
+				match: (item, id) => item.game === id,
+			},
+		]
+
+		const filtered = applyFilters(getMapsWithMainQuest(), filterSpecs)
+		const games = [...new Set(filtered.map(item => item.game))]
+
+		expect(games).toContain("black-ops-1")
+		expect(games).toContain("black-ops-2")
+		expect(filtered).toHaveLength(9)
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes lack of backwards compatibility for manually typed multi-value filter URLs such as `/main-quests?game=black-ops-1&game=black-ops-2`.

The app serializes filters as JSON-encoded arrays (e.g. `game=["black-ops-1","black-ops-2"]`), but users often share links using conventional repeated query keys. This adds an explicit `parseSearch` paired with the existing custom `stringifySearch` so both formats decode to the same validated shape.

## Changes

- Add `src/utils/search-params.ts` with `parseSearch` and normalization for repeated keys / JSON arrays / single values
- Wire `parseSearch` into the router alongside the existing `stringifySearch`
- Coerce parsed array elements to strings so `qss` `toValue` coercion (numbers/booleans) cannot break schema validation
- Add unit tests covering repeated keys, JSON arrays, round-tripping, and main-quest filtering
- Add e2e test for `/main-quests/?game=black-ops-1&game=black-ops-2`

## Verification

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run fmt` — pass
- `bun run test` — pass (325 tests)

## Test plan

- [x] Unit tests for `parseSearch` repeated-key and JSON-array formats
- [x] Integration test confirming both Black Ops 1 and 2 main quest cards are returned
- [x] E2e test for repeated non-JSON query keys (requires dev server in CI)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ead81ad2-8034-48b5-8104-0dd300096862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ead81ad2-8034-48b5-8104-0dd300096862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

Fixes https://github.com/PlagueFPS/cod-zombies/issues/428