### PR TITLE
fix: restore pagination by preserving numeric page search params

### DIFF
--- a/src/utils/search-params.ts
+++ b/src/utils/search-params.ts
@@ -2,7 +2,14 @@ import { parseSearchWith } from "@tanstack/react-router"
 
 const jsonParseSearch = parseSearchWith(JSON.parse)
 
-function normalizeSearchElement(value: unknown): unknown {
+/**
+ * Coerces a multi-value filter element to a string.
+ *
+ * `qss` (via `parseSearchWith`) turns numeric-looking values into numbers/booleans,
+ * which breaks `Schema.ArrayEnsure(Schema.String)`. Applied only to array elements —
+ * scalar numbers like `page` must stay numbers for `Schema.Int`.
+ */
+function normalizeArrayElement(value: unknown): unknown {
 	if (typeof value === "string") {
 		try {
 			const parsed: unknown = JSON.parse(value)
@@ -28,10 +35,10 @@ function normalizeSearchValue(value: unknown): unknown {
 	}
 
 	if (Array.isArray(value)) {
-		return value.map(element => normalizeSearchElement(element))
+		return value.map(element => normalizeArrayElement(element))
 	}
 
-	return normalizeSearchElement(value)
+	return value
 }
 
 /**
@@ -42,6 +49,9 @@ function normalizeSearchValue(value: unknown): unknown {
  * - JSON arrays: `?game=["a","b"]`
  * - Repeated keys: `?game=a&game=b`
  * - Single values: `?game=a`
+ *
+ * Scalar numbers/booleans are left as-is so params like `page` (Schema.Int) still
+ * validate. Only array elements are string-coerced for filter schemas.
  */
 export function normalizeParsedSearch(search: Record<string, unknown>): Record<string, unknown> {
 	const out: Record<string, unknown> = {}

--- a/tests/utils/search-params.test.ts
+++ b/tests/utils/search-params.test.ts
@@ -57,6 +57,26 @@ describe("parseSearch", () => {
 			sort: "oldest",
 		})
 	})
+
+	test("preserves numeric page params for Schema.Int validation", () => {
+		const parsed = parseSearch("page=2")
+		expect(parsed).toEqual({ page: 2 })
+
+		const validated = expectExitSuccess(decodeMainQuestSearchParams(parsed))
+		expect(validated.page).toBe(2)
+	})
+
+	test("preserves page alongside string-coerced filter arrays", () => {
+		const parsed = parseSearch("game=0&game=1&page=3")
+		expect(parsed).toEqual({
+			game: ["0", "1"],
+			page: 3,
+		})
+
+		const validated = expectExitSuccess(decodeMainQuestSearchParams(parsed))
+		expect(validated.game).toEqual(["0", "1"])
+		expect(validated.page).toBe(3)
+	})
 })
 
 describe("normalizeParsedSearch", () => {
@@ -67,6 +87,18 @@ describe("normalizeParsedSearch", () => {
 			}),
 		).toEqual({
 			game: ["0", "1"],
+		})
+	})
+
+	test("does not stringify scalar page numbers", () => {
+		expect(
+			normalizeParsedSearch({
+				page: 2,
+				game: ["black-ops-1"],
+			}),
+		).toEqual({
+			page: 2,
+			game: ["black-ops-1"],
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Root cause from #429: `parseSearch` coerced every number to a string, so `?page=2` became `"2"` and failed `Schema.Int` on listing routes
- String-coerce only multi-value filter array elements; leave scalar numbers like `page` intact
- Add regression tests covering `page` alone and alongside numeric-looking filter arrays

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run fmt`
- [x] `bun run test`
- [x] Manually click next/prev and page buttons on `/main-quests/`, `/side-quests/`, `/bestiary/`, and `/relics/`
- [x] Confirm `?page=2` loads page 2 and URL stays numeric (`page=2`, not a stringified value that fails validation)

Fixes https://github.com/PlagueFPS/cod-zombies/issues/431