### PR TITLE
chore: use Schema.Defect for TaggedErrorClass cause fields

### DIFF
--- a/.cursor/skills/effect/SKILL.md
+++ b/.cursor/skills/effect/SKILL.md
@@ -74,14 +74,14 @@ When the callback must return an `Effect`, yield the error inside a generator or
 
 ## Defining tagged errors
 
-Use `Schema.TaggedErrorClass` with a `_tag`, `message`, and optional `cause`:
+Use `Schema.TaggedErrorClass` with a `cause` and optional `message` if the error is user-facing:
 
 ```typescript
 export class ImageOptimizationError extends Schema.TaggedErrorClass<ImageOptimizationError>()(
   "ImageOptimizationError",
   {
     message: Schema.String,
-    cause: Schema.Unknown,
+    cause: Schema.Defect(),
   },
 ) {}
 ```

--- a/scripts/generate-og-images.tsx
+++ b/scripts/generate-og-images.tsx
@@ -56,7 +56,7 @@ const manifestPathFromEnv = () =>
 export class ImageGenerationError extends Schema.TaggedErrorClass<ImageGenerationError>()(
 	"ImageGenerationError",
 	{
-		cause: Schema.Unknown,
+		cause: Schema.Defect(),
 	},
 ) {}
 

--- a/scripts/image-optimization.ts
+++ b/scripts/image-optimization.ts
@@ -16,7 +16,7 @@ export class ImageOptimizationError extends Schema.TaggedErrorClass<ImageOptimiz
 	"ImageOptimizationError",
 	{
 		message: Schema.String,
-		cause: Schema.Unknown,
+		cause: Schema.Defect(),
 	},
 ) {}
 

--- a/src/data/email.server.ts
+++ b/src/data/email.server.ts
@@ -15,14 +15,14 @@ class ContactExistsError extends Schema.TaggedErrorClass<ContactExistsError>()(
 	"ContactExistsError",
 	{
 		message: Schema.String,
-		cause: Schema.Unknown,
+		cause: Schema.Defect(),
 	},
 ) {}
 class ContactNotFoundError extends Schema.TaggedErrorClass<ContactNotFoundError>()(
 	"ContactNotFoundError",
 	{
 		message: Schema.String,
-		cause: Schema.Unknown,
+		cause: Schema.Defect(),
 	},
 ) {}
 

--- a/src/data/interactive-map.ts
+++ b/src/data/interactive-map.ts
@@ -9,7 +9,7 @@ import { decodeMapConfigModule } from "@/utils/validation-schemas"
 class ConfigNotFoundError extends Schema.TaggedErrorClass<ConfigNotFoundError>()(
 	"ConfigNotFoundError",
 	{
-		cause: Schema.Unknown,
+		cause: Schema.Defect(),
 	},
 ) {}
 

--- a/src/lib/services/emails.ts
+++ b/src/lib/services/emails.ts
@@ -15,7 +15,7 @@ import {
 
 class ResendError extends Schema.TaggedErrorClass<ResendError>()("ResendError", {
 	message: Schema.String,
-	cause: Schema.Unknown,
+	cause: Schema.Defect(),
 }) {}
 
 export class Email extends Context.Service<Email>()("lib/services/emails", {

--- a/src/lib/services/issue-tracker.ts
+++ b/src/lib/services/issue-tracker.ts
@@ -3,7 +3,7 @@ import { Config, Context, Effect, Layer, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest, HttpBody } from "effect/unstable/http"
 
 class CreateIssueError extends Schema.TaggedErrorClass<CreateIssueError>()("CreateIssueError", {
-	cause: Schema.Unknown,
+	cause: Schema.Defect(),
 }) {}
 
 export class IssueTracker extends Context.Service<IssueTracker>()("lib/services/issue-tracker", {

--- a/src/utils/functions.server.ts
+++ b/src/utils/functions.server.ts
@@ -10,21 +10,21 @@ class TokenExpirationError extends Schema.TaggedErrorClass<TokenExpirationError>
 	"TokenExpirationError",
 	{
 		message: Schema.String,
-		cause: Schema.Unknown,
+		cause: Schema.Defect(),
 	},
 ) {}
 class TokenGenerationError extends Schema.TaggedErrorClass<TokenGenerationError>()(
 	"TokenGenerationError",
 	{
 		message: Schema.String,
-		cause: Schema.Unknown,
+		cause: Schema.Defect(),
 	},
 ) {}
 class TokenVerificationError extends Schema.TaggedErrorClass<TokenVerificationError>()(
 	"TokenVerificationError",
 	{
 		message: Schema.String,
-		cause: Schema.Unknown,
+		cause: Schema.Defect(),
 	},
 ) {}
 


### PR DESCRIPTION
## Summary
- Replace `cause: Schema.Unknown` with `cause: Schema.Defect()` on all `Schema.TaggedErrorClass` definitions
- Update the Effect skill docs to match the preferred tagged-error pattern

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run fmt`
- [x] `bun run test` (328 passed)