### PR TITLE
perf: shrink production bundle fonts, ads, and dev tools

### DIFF
--- a/scripts/generate-og-images.tsx
+++ b/scripts/generate-og-images.tsx
@@ -39,6 +39,10 @@ import {
 	type OpengraphKind,
 } from "@/utils/validation-schemas"
 import stylesheet from "@/globals.css?inline"
+import geistMonoCss from "@fontsource-variable/geist-mono/wght.css?inline"
+
+/** App CSS + Geist Mono only for OG renders (Mono is not loaded on the site). */
+const ogStylesheets = [stylesheet, geistMonoCss]
 
 const OPENGRAPH_KINDS = [
 	"main-quests",
@@ -74,6 +78,8 @@ const CARD_SURFACE = "oklch(0.205 0 0)"
 const BORDER = "oklch(1 0 0 / 10%)"
 /** Zombie backdrop color */
 const Z_BG = "oklch(0.145 0 0)"
+/** Loaded only via `ogStylesheets` — not part of the site CSS. */
+const OG_FONT_MONO = "Geist Mono Variable, ui-monospace, monospace"
 
 /** ISO `YYYY-MM-DD` calendar day → long date in en-US; UTC avoids shifting the printed day by local TZ. */
 function formatMapReleaseDay(isoDateOnly: string): string {
@@ -366,7 +372,7 @@ export const generateMainQuestImage = Effect.fnUntraced(
 			{
 				format: "jpeg",
 				...OG_IMAGE_SIZE,
-				stylesheets: [stylesheet],
+				stylesheets: ogStylesheets,
 				persistentImages: [
 					{ data: mapImage, src: `${map.id}-image` },
 					{ data: siteLogo, src: "site-logo" },
@@ -435,7 +441,7 @@ export const generateSideQuestImage = Effect.fnUntraced(
 			{
 				format: "jpeg",
 				...OG_IMAGE_SIZE,
-				stylesheets: [stylesheet],
+				stylesheets: ogStylesheets,
 				persistentImages: [
 					{ data: mapImage, src: `${map.id}-image` },
 					{ data: siteLogo, src: "site-logo" },
@@ -520,7 +526,7 @@ export const generateZombieImage = Effect.fnUntraced(
 					tw="text-lg font-bold uppercase tracking-[0.07em] shrink-0"
 					style={{
 						color: MUTED_FG,
-						fontFamily: "Geist Mono Variable, ui-monospace, monospace",
+						fontFamily: OG_FONT_MONO,
 					}}
 				>
 					Attacks
@@ -529,7 +535,7 @@ export const generateZombieImage = Effect.fnUntraced(
 					tw="text-lg font-semibold leading-snug break-words min-w-0"
 					style={{
 						color: typeMetaColor,
-						fontFamily: "Geist Mono Variable, ui-monospace, monospace",
+						fontFamily: OG_FONT_MONO,
 					}}
 				>
 					{attackStr}
@@ -675,7 +681,7 @@ export const generateZombieImage = Effect.fnUntraced(
 							<p
 								tw="text-lg font-semibold uppercase tracking-[0.07em] mt-1 shrink-0 flex flex-row flex-wrap"
 								style={{
-									fontFamily: "Geist Mono Variable, ui-monospace, monospace",
+									fontFamily: OG_FONT_MONO,
 								}}
 							>
 								<span style={{ color: MUTED_FG }}>First appearance · </span>
@@ -711,7 +717,7 @@ export const generateZombieImage = Effect.fnUntraced(
 														tw="text-lg font-bold uppercase tracking-[0.07em] shrink-0"
 														style={{
 															color: MUTED_FG,
-															fontFamily: "Geist Mono Variable, ui-monospace, monospace",
+															fontFamily: OG_FONT_MONO,
 														}}
 													>
 														Weak points
@@ -720,7 +726,7 @@ export const generateZombieImage = Effect.fnUntraced(
 														tw="text-lg font-semibold leading-snug break-words min-w-0"
 														style={{
 															color: typeMetaColor,
-															fontFamily: "Geist Mono Variable, ui-monospace, monospace",
+															fontFamily: OG_FONT_MONO,
 														}}
 													>
 														{weakStr}
@@ -740,7 +746,7 @@ export const generateZombieImage = Effect.fnUntraced(
 														tw="text-lg font-bold uppercase tracking-[0.07em] shrink-0"
 														style={{
 															color: MUTED_FG,
-															fontFamily: "Geist Mono Variable, ui-monospace, monospace",
+															fontFamily: OG_FONT_MONO,
 														}}
 													>
 														Elemental weaknesses
@@ -767,7 +773,7 @@ export const generateZombieImage = Effect.fnUntraced(
 																	tw="text-lg font-semibold leading-snug"
 																	style={{
 																		color: typeMetaColor,
-																		fontFamily: "Geist Mono Variable, ui-monospace, monospace",
+																		fontFamily: OG_FONT_MONO,
 																	}}
 																>
 																	—
@@ -790,7 +796,7 @@ export const generateZombieImage = Effect.fnUntraced(
 			{
 				format: "jpeg",
 				...OG_IMAGE_SIZE,
-				stylesheets: [stylesheet],
+				stylesheets: ogStylesheets,
 				persistentImages: [
 					{ data: zombieImage, src: `${zombie.id}-portrait` },
 					{ data: siteLogo, src: "site-logo" },
@@ -957,7 +963,7 @@ export const generateRelicImage = Effect.fnUntraced(
 							<p
 								tw="text-lg font-semibold uppercase tracking-[0.07em] mt-1 shrink-0 flex flex-row flex-wrap"
 								style={{
-									fontFamily: "Geist Mono Variable, ui-monospace, monospace",
+									fontFamily: OG_FONT_MONO,
 								}}
 							>
 								<span style={{ color: MUTED_FG }}>Map · </span>
@@ -987,7 +993,7 @@ export const generateRelicImage = Effect.fnUntraced(
 			{
 				format: "jpeg",
 				...OG_IMAGE_SIZE,
-				stylesheets: [stylesheet],
+				stylesheets: ogStylesheets,
 				persistentImages: [
 					{ data: relicImage, src: `${relic.id}-portrait` },
 					{ data: siteLogo, src: "site-logo" },

--- a/src/components/react-scan.tsx
+++ b/src/components/react-scan.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from "react"
 import { scan } from "react-scan"
-import { IN_DEVELOPMENT } from "@/utils/constants"
 
+/** Loaded only in development via `import.meta.env.DEV` dynamic import from `__root`. */
 export default function ReactScan() {
 	useEffect(() => {
 		scan({
-			enabled: IN_DEVELOPMENT,
+			enabled: true,
 			showFPS: true,
 			showToolbar: true,
 			showNotificationCount: true,

--- a/src/components/shattered-veil-chalkboard-code.tsx
+++ b/src/components/shattered-veil-chalkboard-code.tsx
@@ -68,7 +68,7 @@ export default function ShatteredVeilCode() {
 						<div className="border-t pt-4">
 							<p className="mb-2 text-sm text-foreground/90">Your Code:</p>
 							<div className="rounded-lg bg-muted p-4 dark:bg-input/30">
-								<code className="font-mono text-lg font-semibold text-foreground">
+								<code className="text-lg font-semibold text-foreground">
 									{chalkboardCodes[letterGroup][codeWord]}
 								</code>
 							</div>

--- a/src/components/shortcut.tsx
+++ b/src/components/shortcut.tsx
@@ -28,7 +28,7 @@ interface ShortcutWithShortcuts {
 type ShortcutProps = ShortcutWithChildren | ShortcutWithShortcuts
 
 const shortcutVariants = cva(
-	"inline-flex items-center justify-center font-mono font-medium rounded border transition-colors",
+	"inline-flex items-center justify-center font-medium rounded border transition-colors",
 	{
 		variants: {
 			variant: {

--- a/src/components/weapon-build-tooltip.tsx
+++ b/src/components/weapon-build-tooltip.tsx
@@ -84,7 +84,7 @@ const WeaponBuildTooltipContent = ({ weaponBuild }: { weaponBuild: WeaponBuild }
 						<div className="mb-5">
 							<div className="flex items-center gap-3 rounded-lg border border-primary/30 bg-primary/10 p-3 backdrop-blur-sm">
 								<span className="font-medium">Build Code:</span>
-								<code className="flex-1 rounded-sm bg-input/30 p-2 font-mono text-sm font-semibold text-primary">
+								<code className="flex-1 rounded-sm bg-input/30 p-2 text-sm font-semibold text-primary">
 									{buildCode}
 								</code>
 								<Button

--- a/src/globals.css
+++ b/src/globals.css
@@ -1,7 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "@fontsource-variable/geist/wght.css";
-@import "@fontsource-variable/geist-mono/wght.css";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -232,7 +231,6 @@
 	--color-major-augment-foreground: var(--major-augment-foreground);
 	--color-blockquote-foreground: var(--blockquote-foreground);
 
-	--font-mono: "Geist Mono Variable", monospace;
 	--font-sans: "Geist Variable", sans-serif;
 
 	--radius-lg: var(--radius);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -17,7 +17,7 @@ import { IN_DEVELOPMENT, SITE_DESCRIPTION, SITE_TITLE } from "@/utils/constants"
 import appCss from "@/globals.css?url"
 
 /** Dev-only: dynamic import so `react-scan` is omitted from production bundles. */
-const ReactScan = import.meta.env.DEV ? lazy(() => import("@/components/react-scan")) : null
+const ReactScan = import.meta.env.DEV ? lazy(() => import("../components/react-scan")) : null
 
 interface RouterContext {
 	serverUrl: string

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,12 +9,15 @@ import {
 	createRootRouteWithContext,
 } from "@tanstack/react-router"
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools"
+import { lazy, Suspense } from "react"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
-import ReactScan from "@/components/react-scan"
 import { Toaster } from "@/components/ui/sonner"
 import { IN_DEVELOPMENT, SITE_DESCRIPTION, SITE_TITLE } from "@/utils/constants"
 import appCss from "@/globals.css?url"
+
+/** Dev-only: dynamic import so `react-scan` is omitted from production bundles. */
+const ReactScan = import.meta.env.DEV ? lazy(() => import("@/components/react-scan")) : null
 
 interface RouterContext {
 	serverUrl: string
@@ -42,7 +45,9 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 		],
 		scripts: [
 			{
+				async: true,
 				src: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2572200153117332",
+				crossOrigin: "anonymous",
 			},
 		],
 	}),
@@ -75,22 +80,28 @@ function RootLayout() {
 				<Footer />
 				<Toaster richColors position="top-center" closeButton />
 				<Scripts />
-				<TanStackDevtools
-					config={{ position: "bottom-left" }}
-					eventBusConfig={{ connectToServerBus: true }}
-					plugins={[
-						{
-							name: "TanStack Router",
-							render: <TanStackRouterDevtoolsPanel />,
-						},
-						{
-							name: "TanStack Query",
-							render: <ReactQueryDevtools />,
-						},
-					]}
-				/>
+				{IN_DEVELOPMENT && (
+					<TanStackDevtools
+						config={{ position: "bottom-left" }}
+						eventBusConfig={{ connectToServerBus: true }}
+						plugins={[
+							{
+								name: "TanStack Router",
+								render: <TanStackRouterDevtoolsPanel />,
+							},
+							{
+								name: "TanStack Query",
+								render: <ReactQueryDevtools />,
+							},
+						]}
+					/>
+				)}
 			</body>
-			{IN_DEVELOPMENT && <ReactScan />}
+			{ReactScan ? (
+				<Suspense fallback={null}>
+					<ReactScan />
+				</Suspense>
+			) : null}
 		</html>
 	)
 }


### PR DESCRIPTION
## Summary
- Keep Geist Mono out of site CSS (load it only in the OG image script) so production no longer ships Mono font files
- Load AdSense with `async` + `crossOrigin` to avoid blocking the parser
- Gate TanStack Devtools behind development and load ReactScan only via `import.meta.env.DEV` dynamic import so it is omitted from production JS

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run fmt`
- [x] `bun run test` (328 tests)
- [x] `bun run build` — confirmed no Mono woff2 in client assets, no `react-scan` in client chunks, AdSense script is async; index.js ~223KB smaller after ReactScan exclusion