### PR TITLE
fix: detail-page hero LCP (glow → CardImageGlow)

### DIFF
--- a/src/routes/bestiary.$zombieId.tsx
+++ b/src/routes/bestiary.$zombieId.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react"
 import AmmoModTooltip from "@/components/ammo-mod-tooltip"
 import { Breadcrumbs, type Link } from "@/components/breadcrumbs"
+import { CardImageGlow } from "@/components/card-image-glow"
 import { ComingSoonBadge, NewBadge, RangeBadge, TypeBadge } from "@/components/custom-badges"
 import { CustomLink } from "@/components/custom-link"
 import { FeaturedImage } from "@/components/featured-image"
@@ -174,17 +175,7 @@ function ZombieInfo() {
 				<CardContent>
 					<section className="grid grid-cols-1 gap-6 md:grid-cols-3">
 						<div className="relative flex flex-col items-center">
-							<div className="pointer-events-none absolute inset-0 mx-auto hidden w-full opacity-35 blur-3xl dark:block">
-								<FeaturedImage
-									featuredImage={zombie.image}
-									alt=""
-									width={422}
-									height={422}
-									sizes="422px"
-									loading="eager"
-									className="mb-4 aspect-square w-full rounded-lg object-cover object-top"
-								/>
-							</div>
+							<CardImageGlow src={zombie.image} className="opacity-35 blur-3xl" />
 							<FeaturedImage
 								featuredImage={zombie.image}
 								alt={`${zombie.title} image`}
@@ -193,6 +184,7 @@ function ZombieInfo() {
 								sizes="422px"
 								preload
 								loading="eager"
+								fetchPriority="high"
 								className="mb-4 aspect-square w-full overflow-hidden rounded-lg object-cover object-top shadow-lg dark:shadow-none"
 							/>
 							<div className="w-full space-y-3">
@@ -450,16 +442,7 @@ function PrevOrNextZombieCard({ zombie, prev }: PrevOrNextZombieCardProps) {
 						{firstAppearedIn.title}
 					</Badge>
 				</div>
-				<div className="absolute inset-0 z-10 hidden h-full w-full items-center opacity-35 blur-2xl dark:flex">
-					<FeaturedImage
-						featuredImage={zombie.image}
-						alt=""
-						width={384}
-						height={176}
-						sizes="(max-width: 1280px) 320px, 384px"
-						className="scale-110"
-					/>
-				</div>
+				<CardImageGlow src={zombie.image} className="scale-110 opacity-35" />
 				<div className="relative z-20 flex h-full w-full max-w-sm items-center justify-center overflow-hidden rounded-lg">
 					<FeaturedImage
 						featuredImage={zombie.image}

--- a/src/routes/bestiary.$zombieId.tsx
+++ b/src/routes/bestiary.$zombieId.tsx
@@ -176,40 +176,44 @@ function ZombieInfo() {
 					<section className="grid grid-cols-1 gap-6 md:grid-cols-3">
 						<div className="relative flex flex-col items-center">
 							<CardImageGlow src={zombie.image} className="opacity-35 blur-3xl" />
-							<FeaturedImage
-								featuredImage={zombie.image}
-								alt={`${zombie.title} image`}
-								width={422}
-								height={422}
-								sizes="422px"
-								preload
-								loading="eager"
-								fetchPriority="high"
-								className="mb-4 aspect-square w-full overflow-hidden rounded-lg object-cover object-top shadow-lg dark:shadow-none"
-							/>
-							<div className="w-full space-y-3">
-								<div>
-									<div className="flex flex-wrap items-center justify-between">
-										<div className="flex items-center gap-2">
-											<Eye className="size-5 text-orange-500" />
+							<div className="relative z-20 flex w-full flex-col items-center">
+								<FeaturedImage
+									featuredImage={zombie.image}
+									alt={`${zombie.title} image`}
+									width={422}
+									height={422}
+									sizes="422px"
+									preload
+									loading="eager"
+									fetchPriority="high"
+									className="mb-4 aspect-square w-full overflow-hidden rounded-lg object-cover object-top shadow-lg dark:shadow-none"
+								/>
+								<div className="w-full space-y-3">
+									<div>
+										<div className="flex flex-wrap items-center justify-between">
+											<div className="flex items-center gap-2">
+												<Eye className="size-5 text-orange-500" />
+												<span className="text-foreground dark:text-foreground/80">
+													First Appeared In
+												</span>
+											</div>
 											<span className="text-foreground dark:text-foreground/80">
-												First Appeared In
+												{firstAppearIn.title}
 											</span>
 										</div>
-										<span className="text-foreground dark:text-foreground/80">
-											{firstAppearIn.title}
-										</span>
 									</div>
-								</div>
-								<div>
-									<div className="flex items-center justify-between">
-										<div className="flex items-center gap-2">
-											<Zap className="size-5 text-yellow-500" />
-											<span className="text-foreground dark:text-foreground/80">Speed</span>
+									<div>
+										<div className="flex items-center justify-between">
+											<div className="flex items-center gap-2">
+												<Zap className="size-5 text-yellow-500" />
+												<span className="text-foreground dark:text-foreground/80">Speed</span>
+											</div>
+											<span className="text-foreground dark:text-foreground/80">
+												{zombie.speed}
+											</span>
 										</div>
-										<span className="text-foreground dark:text-foreground/80">{zombie.speed}</span>
+										<Progress value={speedProgress()} className="mt-1 h-2" />
 									</div>
-									<Progress value={speedProgress()} className="mt-1 h-2" />
 								</div>
 							</div>
 						</div>

--- a/src/routes/main-quests.$gameId.$mapId.tsx
+++ b/src/routes/main-quests.$gameId.$mapId.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router"
 import { Option } from "effect"
 import { Calendar, ChevronLeft, ChevronRight, Clock } from "lucide-react"
 import { Breadcrumbs, type Link } from "@/components/breadcrumbs"
+import { CardImageGlow } from "@/components/card-image-glow"
 import { CompletionTimeDisplay } from "@/components/completion-time-display"
 import { ComingSoonBadge, DifficultyBadge, NewBadge } from "@/components/custom-badges"
 import { CustomLink } from "@/components/custom-link"
@@ -98,16 +99,10 @@ function MainQuestGuide() {
 					<TableOfContents headings={meta.headings} />
 					<article className="flex w-full flex-col items-center justify-center">
 						<div className="relative mt-16 w-full xl:mt-8">
-							<div className="absolute top-4 right-0 left-0 mx-auto hidden w-full max-w-7xl opacity-35 blur-3xl sm:dark:block">
-								<FeaturedImage
-									featuredImage={map.image}
-									alt=""
-									width={1280}
-									height={720}
-									loading="eager"
-									sizes="(max-width: 1280px) 100vw, 1280px"
-								/>
-							</div>
+							<CardImageGlow
+								src={map.image}
+								className="opacity-35 blur-3xl dark:hidden sm:dark:block"
+							/>
 							<div className="relative mx-auto max-w-7xl">
 								<FeaturedImage
 									featuredImage={map.image}
@@ -115,6 +110,8 @@ function MainQuestGuide() {
 									width={1280}
 									height={720}
 									sizes="(max-width: 1280px) 100vw, 1280px"
+									loading="eager"
+									fetchPriority="high"
 									preload
 									className="overflow-hidden xl:rounded-lg"
 								/>
@@ -234,16 +231,7 @@ function PrevOrNextMapCard({ map, prev }: PrevOrNextCard) {
 						{game.title}
 					</Badge>
 				</div>
-				<div className="absolute inset-0 z-10 hidden h-full w-full items-center opacity-35 blur-2xl dark:flex">
-					<FeaturedImage
-						featuredImage={map.image}
-						alt={alt}
-						width={384}
-						height={176}
-						sizes="(max-width: 1280px) 320px, 384px"
-						className="scale-110"
-					/>
-				</div>
+				<CardImageGlow src={map.image} className="scale-110 opacity-35" />
 				<div className="relative z-20 flex h-full w-full max-w-sm items-center justify-center overflow-hidden rounded-lg">
 					<FeaturedImage
 						featuredImage={map.image}

--- a/src/routes/main-quests.$gameId.$mapId.tsx
+++ b/src/routes/main-quests.$gameId.$mapId.tsx
@@ -99,10 +99,9 @@ function MainQuestGuide() {
 					<TableOfContents headings={meta.headings} />
 					<article className="flex w-full flex-col items-center justify-center">
 						<div className="relative mt-16 w-full xl:mt-8">
-							<CardImageGlow
-								src={map.image}
-								className="opacity-35 blur-3xl dark:hidden sm:dark:block"
-							/>
+							<div className="pointer-events-none absolute top-4 right-0 left-0 mx-auto hidden aspect-video w-full max-w-7xl sm:dark:block">
+								<CardImageGlow src={map.image} className="opacity-35 blur-3xl" />
+							</div>
 							<div className="relative mx-auto max-w-7xl">
 								<FeaturedImage
 									featuredImage={map.image}

--- a/src/routes/side-quests.$gameId.$mapId.$questId.tsx
+++ b/src/routes/side-quests.$gameId.$mapId.$questId.tsx
@@ -102,10 +102,9 @@ function SideQuestGuide() {
 					<TableOfContents headings={meta.headings} />
 					<article className="flex w-full flex-col items-center justify-center">
 						<div className="relative mt-16 w-full xl:mt-8">
-							<CardImageGlow
-								src={map.image}
-								className="opacity-35 blur-3xl dark:hidden sm:dark:block"
-							/>
+							<div className="pointer-events-none absolute top-4 right-0 left-0 mx-auto hidden aspect-video w-full max-w-7xl sm:dark:block">
+								<CardImageGlow src={map.image} className="opacity-35 blur-3xl" />
+							</div>
 							<div className="relative mx-auto max-w-7xl">
 								<FeaturedImage
 									featuredImage={map.image}

--- a/src/routes/side-quests.$gameId.$mapId.$questId.tsx
+++ b/src/routes/side-quests.$gameId.$mapId.$questId.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router"
 import { Option } from "effect"
 import { Calendar, ChevronLeft, ChevronRight, Clock } from "lucide-react"
 import { Breadcrumbs, type Link } from "@/components/breadcrumbs"
+import { CardImageGlow } from "@/components/card-image-glow"
 import { ComingSoonBadge, NewBadge } from "@/components/custom-badges"
 import { CustomLink } from "@/components/custom-link"
 import { FeaturedImage } from "@/components/featured-image"
@@ -101,16 +102,10 @@ function SideQuestGuide() {
 					<TableOfContents headings={meta.headings} />
 					<article className="flex w-full flex-col items-center justify-center">
 						<div className="relative mt-16 w-full xl:mt-8">
-							<div className="absolute top-4 right-0 left-0 mx-auto hidden w-full max-w-7xl opacity-35 blur-3xl sm:dark:block">
-								<FeaturedImage
-									featuredImage={map.image}
-									alt=""
-									width={1280}
-									height={720}
-									sizes="(max-width: 1280px) 100vw, 1280px"
-									loading="eager"
-								/>
-							</div>
+							<CardImageGlow
+								src={map.image}
+								className="opacity-35 blur-3xl dark:hidden sm:dark:block"
+							/>
 							<div className="relative mx-auto max-w-7xl">
 								<FeaturedImage
 									featuredImage={map.image}
@@ -118,8 +113,10 @@ function SideQuestGuide() {
 									width={1280}
 									height={720}
 									sizes="(max-width: 1280px) 100vw, 1280px"
-									className="overflow-hidden xl:rounded-lg"
+									loading="eager"
+									fetchPriority="high"
 									preload
+									className="overflow-hidden xl:rounded-lg"
 								/>
 								<div className="absolute -top-10 left-0 flex w-full justify-center pl-4 xl:pl-0">
 									<Breadcrumbs
@@ -251,16 +248,7 @@ function PrevOrNextQuestCard({ quest, prev }: PrevOrNextCard) {
 						{game.title}
 					</Badge>
 				</div>
-				<div className="absolute inset-0 z-10 hidden h-full w-full items-center opacity-35 blur-2xl dark:flex">
-					<FeaturedImage
-						featuredImage={map.image}
-						alt={alt}
-						width={384}
-						height={176}
-						sizes="(max-width: 1280px) 320px, 384px"
-						className="scale-110"
-					/>
-				</div>
+				<CardImageGlow src={map.image} className="scale-110 opacity-35" />
 				<div className="relative z-20 flex h-full w-full max-w-sm items-center justify-center overflow-hidden rounded-lg">
 					<FeaturedImage
 						featuredImage={map.image}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Decorative dark-mode hero “glow” copies were second `<FeaturedImage>` elements marked `loading="eager"`, so React 19 SSR could prioritize them over the real hero (which often had `preload` but defaulted to lazy/`opacity-0`).

This PR mirrors the home/card fix:

- Replace glow `<FeaturedImage>` blocks with `CardImageGlow` (CSS `background-image` of the 384w variant — no second `<img>`, no eager/preload) on:
  - main-quest detail hero + prev/next cards
  - side-quest detail hero + prev/next cards
  - bestiary detail hero + prev/next cards
- Mark primary heroes `loading="eager"`, `fetchPriority="high"`, and keep `preload` so they paint at full opacity via the existing LCP path in `FeaturedImage`.

## Test plan
- [x] Dark mode: main-quest / side-quest / bestiary detail pages still show a soft blurred glow behind the hero
- [x] Light mode: no glow visible
- [x] Hero image loads immediately (no fade-from-opacity-0)
- [x] Prev/next cards keep dark-mode glow without competing for LCP
- [x] `bun run typecheck && bun run lint && bun run fmt && bun run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba355fda-fd76-428c-b85e-4c55994cc3bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba355fda-fd76-428c-b85e-4c55994cc3bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

